### PR TITLE
Fixes #11. CI: Update setup-python to v4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: Set up Python 3.10
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: "3.10"
     - name: Install dependencies


### PR DESCRIPTION
- To resolve a deprecated warning regarding 'set-output'