### PR TITLE
Fixes #25. Reverting Python 3.11 claimed support, that was too soon

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ See the documentation at [Read The Docs](https://cruiz.readthedocs.io/).
   - macOS (10.13+)
 - Apple Silicon platforms:
   - macOS (11.0+)
-- Python 3.7-3.11
+- Python 3.7-3.10
 - Conan 1.17.1+, but not 2.x (these are the versions tested)
 
 All other Python dependencies are installed when the package is installed.

--- a/setup.py
+++ b/setup.py
@@ -153,9 +153,8 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
-        "Programming Language :: Python :: 3.11",
     ],
-    python_requires=">=3.7, <3.12",
+    python_requires=">=3.7, <3.11",
     project_urls={
         'Documentation': 'https://cruiz.readthedocs.io/en/latest/',
         'GitHub': 'https://github.com/markfinal/cruiz',


### PR DESCRIPTION
Revert "Python 3.11: A test against 3.11-rc2 suggested it was working, so adding 3.11 to the version support"

This reverts commit 94f2d292b35f53e056c12d1bd0c64c92d172afe5.