### PR TITLE
Fixes #33. Command history widget. Don't show disabled context menu

### DIFF
--- a/cruiz/recipe/logs/command.py
+++ b/cruiz/recipe/logs/command.py
@@ -82,10 +82,12 @@ class RecipeCommandHistoryWidget(QtWidgets.QListWidget):
         )
 
     def _show_context_menu(self, position: QtCore.QPoint) -> None:
+        if not any(self.selectedItems()):
+            return
         self._menu.exec_(self.mapToGlobal(position))
 
     def _selection_changed(self) -> None:
-        enabled = bool(self.selectedItems())
+        enabled = any(self.selectedItems())
         self._menu.setEnabled(enabled)
 
     def _export_bash(self) -> None:


### PR DESCRIPTION
- the menu is for exporting the selected command in the history, so when there is nothing selected, no menu should show
- the experience isn't great when the menu briefly shows all disabled and closes quickly