### PR TITLE
Fixes #35. CMake commands didn't know the CMakeCache.txt location for…

### DIFF
--- a/cruiz/interop/packagenode.py
+++ b/cruiz/interop/packagenode.py
@@ -23,6 +23,7 @@ class PackageNode:
     short_paths: bool
     info: typing.Optional[str]
     is_runtime: bool
+    layout_build_subdir: str
     children: typing.List[PackageNode] = field(default_factory=list)
     parents: typing.List[PackageNode] = field(default_factory=list)
 
@@ -35,6 +36,7 @@ class PackageNode:
             self.short_paths,
             self.info,
             self.is_runtime,
+            self.layout_build_subdir,
             [],
             [],
         )

--- a/cruiz/recipe/toolbars/command.py
+++ b/cruiz/recipe/toolbars/command.py
@@ -705,8 +705,14 @@ class RecipeCommandToolbar(QtWidgets.QToolBar):
             workflow_cwd = settings.local_workflow_cwd.resolve()
             common_subdir = settings.local_workflow_common_subdir.resolve()
             params.cwd = recipe_widget.get_working_dir(workflow_cwd, common_subdir)
-            build_folder = settings.local_workflow_build_folder.resolve()
-            params.build_folder = recipe_widget.resolve_expression(build_folder)
+            layout_build_subdir = (
+                recipe_widget._dependency_graph.root.layout_build_subdir
+            )
+            if layout_build_subdir:
+                params.build_folder = layout_build_subdir
+            else:
+                build_folder = settings.local_workflow_build_folder.resolve()
+                params.build_folder = recipe_widget.resolve_expression(build_folder)
         if args:
             params.arguments.extend(args)
         self.command_started.emit()
@@ -729,8 +735,14 @@ class RecipeCommandToolbar(QtWidgets.QToolBar):
             workflow_cwd = settings.local_workflow_cwd.resolve()
             common_subdir = settings.local_workflow_common_subdir.resolve()
             params.cwd = recipe_widget.get_working_dir(workflow_cwd, common_subdir)
-            build_folder = settings.local_workflow_build_folder.resolve()
-            params.build_folder = recipe_widget.resolve_expression(build_folder)
+            layout_build_subdir = (
+                recipe_widget._dependency_graph.root.layout_build_subdir
+            )
+            if layout_build_subdir:
+                params.build_folder = layout_build_subdir
+            else:
+                build_folder = settings.local_workflow_build_folder.resolve()
+                params.build_folder = recipe_widget.resolve_expression(build_folder)
         self.command_started.emit()
         recipe.context.cmakebuildcommand(params, self)
 

--- a/cruiz/workers/lockcreate.py
+++ b/cruiz/workers/lockcreate.py
@@ -97,6 +97,12 @@ def invoke(queue: multiprocessing.Queue[Message], params: CommandParameters) -> 
                 # node.conanfile.original_info is only available from Conan 1.47.0+
                 info = None
 
+            # layouts folders were introduced in 1.37
+            try:
+                build_folder = node.conanfile.folders.build
+            except AttributeError:
+                build_folder = None
+
             if node.recipe in (RECIPE_CONSUMER, RECIPE_VIRTUAL):
                 new_node = PackageNode(
                     node.name,
@@ -106,6 +112,7 @@ def invoke(queue: multiprocessing.Queue[Message], params: CommandParameters) -> 
                     node.conanfile.short_paths,
                     info,
                     True,
+                    build_folder,
                 )
                 nodes[node] = new_node
                 continue
@@ -120,6 +127,7 @@ def invoke(queue: multiprocessing.Queue[Message], params: CommandParameters) -> 
                 node.conanfile.short_paths,
                 info,
                 is_runtime,
+                build_folder,
             )
             nodes[node] = new_node
 


### PR DESCRIPTION
… layout recipes

- the full interaction with layouts and specifying the local workflow folders hasn't been fully explored by the author, so there may be loopholes