### PR TITLE
Fixes for extra profile directories

### DIFF
--- a/cruiz/recipe/recipewidget.py
+++ b/cruiz/recipe/recipewidget.py
@@ -463,9 +463,13 @@ class RecipeWidget(QtWidgets.QMainWindow):
                     settings_localcache.extra_profile_directories.resolve()
                 )
             extra_profile_dir_name = [
-                x for x in extra_profile_dirs if profile.startswith(x)
+                name
+                for name, profile_dir in extra_profile_dirs.items()
+                if pathlib.Path(profile).is_relative_to(pathlib.Path(profile_dir))
             ]
-            assert len(extra_profile_dir_name) == 1
+            assert (
+                len(extra_profile_dir_name) == 1
+            ), f"Unable to locate profile {profile} on extra dirs {extra_profile_dirs}"
             profile_prefix = f"{extra_profile_dir_name[0]}-"
         else:
             profile_prefix = ""

--- a/cruiz/recipe/recipewidget.py
+++ b/cruiz/recipe/recipewidget.py
@@ -523,7 +523,7 @@ class RecipeWidget(QtWidgets.QMainWindow):
             self._ui.commandToolbar.configure_actions()  # this is a one off
             self._ui.commandToolbar.refresh_action_shortcuts_and_tooltips(attributes)
         except Exception as exc:
-            logging.debug("Updating toolbars suppressed: '%s'", str(exc))
+            logging.exception("Updating toolbars suppressed: '%s'", str(exc))
             self._ui.commandToolbar.disable_all_actions()
 
     def _create_statusbar(self) -> None:


### PR DESCRIPTION
- debug only messages when the commands were disabled due to an exception
- determining the extra profile directory names was incorrect, causing an exception