### PR TITLE
Fixes #49. Remote browser. Avoid Conan types in return data for packa…

### DIFF
--- a/cruiz/workers/packagedetails.py
+++ b/cruiz/workers/packagedetails.py
@@ -29,4 +29,18 @@ def invoke(queue: multiprocessing.Queue[Message], params: PackageIdParameters) -
         )
         results_list = result["results"][0]["items"][0]["packages"]
 
+        import conans
+
+        for entry in results_list:
+            if "options" in entry:
+                new_options = {}
+                for option_key, option_value in entry["options"].items():
+                    if isinstance(
+                        option_value, conans.model.options.PackageOptionValue
+                    ):
+                        new_options[option_key] = str(option_value)
+                    else:
+                        new_options[option_key] = option_value
+                entry["options"] = new_options
+
         queue.put(Success(results_list or None))


### PR DESCRIPTION
…ge_ids

From Conan 1.48, searching for package_ids and related data, returns option values as conans.model.options.PackageOptionValue, which must not be returned to the cruiz UI process.

It does not happen for every Artifactory server instance, which is curious.

This change detects this scenario, and stringifies the option value.