### PR TITLE
Fixes #46. Submenu parentage should be to the parent menu

### DIFF
--- a/cruiz/mainwindow.py
+++ b/cruiz/mainwindow.py
@@ -115,8 +115,6 @@ class MainWindow(QtWidgets.QMainWindow):
         open_recipe_action.setShortcut(QtGui.QKeySequence("Ctrl+O"))
         open_recipe_action.triggered.connect(self._open_recipe)
 
-        self._recent_recipe_menu = QtWidgets.QMenu("Recent recipes", self)
-
         exit_action = QtGui.QAction("&Quit", self)
         exit_action.setMenuRole(QtGui.QAction.QuitRole)
         exit_action.setShortcut(QtGui.QKeySequence("Ctrl+Q"))
@@ -140,6 +138,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
         menubar = self.menuBar()
         file_menu = menubar.addMenu("&File")
+        self._recent_recipe_menu = QtWidgets.QMenu("Recent recipes", file_menu)
         file_menu.aboutToShow.connect(self._rebuild_recent_recipe_menu)
         file_menu.addAction(open_recipe_action)
         file_menu.addMenu(self._recent_recipe_menu)

--- a/cruiz/manage_local_cache/widgets/configpathorurl.py
+++ b/cruiz/manage_local_cache/widgets/configpathorurl.py
@@ -23,5 +23,6 @@ class LineEditWithCustomContextMenu(QtWidgets.QLineEdit):
         menu = self.createStandardContextMenu()
         if self._custom_menu:
             menu.addSeparator()
+            self._custom_menu.setParent(menu)
             menu.addMenu(self._custom_menu)
         menu.exec_(event.globalPos())

--- a/cruiz/settings/preferencesdialog.py
+++ b/cruiz/settings/preferencesdialog.py
@@ -1067,13 +1067,15 @@ class PreferencesDialog(QtWidgets.QDialog):
         forget_recipe_action.setData(uuid)
         forget_recipe_action.triggered.connect(self._recipes_forget_recipe)
         menu.addSeparator()
-        menu.addMenu(self._recipes_build_change_cache_menu(uuid)).setText(
+        menu.addMenu(self._recipes_build_change_cache_menu(uuid, menu)).setText(
             "Change local cache to"
         )
         menu.exec_(self._ui.prefs_recipes_table.viewport().mapToGlobal(position))
 
-    def _recipes_build_change_cache_menu(self, uuid: QtCore.QUuid) -> QtWidgets.QMenu:
-        menu = QtWidgets.QMenu(self)
+    def _recipes_build_change_cache_menu(
+        self, uuid: QtCore.QUuid, parent_menu: QtWidgets.QMenu
+    ) -> QtWidgets.QMenu:
+        menu = QtWidgets.QMenu(parent_menu)
         with RecipeSettingsReader.from_uuid(uuid) as settings:
             uuid_local_cache = settings.local_cache_name.resolve()
         with AllNamedLocalCacheSettingsReader() as cache_names:


### PR DESCRIPTION
This was giving a warning on Weyland if the parent was not set correctly.

WARNING:cruiz.entrypoint:setGrabPopup called with a parent, QtWaylandClient::QWaylandXdgSurface(0x55c528e78d30) which does not match the current topmost grabbing popup, QtWaylandClient::QWaylandXdgSurface(0x55c528e91760) According to the xdg-shell protocol, this is not allowed. The wayland QPA plugin is currently handling it by setting the parent to the topmost grabbing popup. Note, however, that this may cause positioning errors and popups closing unxpectedly because xdg-shell mandate that child popups close before parents