### PR TITLE
Fixes #66. Local cache. Moving now updates the meta invocation

### DIFF
--- a/cruiz/commands/context.py
+++ b/cruiz/commands/context.py
@@ -114,13 +114,13 @@ class ConanContext(QtCore.QObject):
             # don't double close this
             pass
 
-    def change_cache(self, cache_name: str) -> None:
+    def change_cache(self, cache_name: str, force: bool = False) -> None:
         """
         Change the local cache used by this context.
         """
         # don't even try to check for a name no-op if the cache has already been closed
         if hasattr(self, "_meta_invocation"):
-            if cache_name == self.cache_name:
+            if cache_name == self.cache_name and not force:
                 return
             assert not self.is_busy
             self.close()

--- a/cruiz/manage_local_cache/managelocalcachesdialog.py
+++ b/cruiz/manage_local_cache/managelocalcachesdialog.py
@@ -357,7 +357,8 @@ class ManageLocalCachesDialog(QtWidgets.QDialog):
                 )
 
     def _update_cache_details(self, cache_name: str) -> None:
-        self._context.change_cache(cache_name)
+        force_change = self._context.cache_name == cache_name
+        self._context.change_cache(cache_name, force=force_change)
         with NamedLocalCacheSettingsReader(cache_name) as settings:
             home_dir = settings.home_dir.resolve()
             short_home_dir = settings.short_home_dir.resolve()


### PR DESCRIPTION
The long running process (meta invocation) of each context, did not get restarted when the cache was moved, so requests running through it still acted upon the previous home directory for the cache.