### PR TITLE
Fixes #81. Custom submenus no longer overwriting parent menu

### DIFF
--- a/cruiz/manage_local_cache/widgets/addenvironmentdialog.py
+++ b/cruiz/manage_local_cache/widgets/addenvironmentdialog.py
@@ -5,6 +5,7 @@ Dialog for adding an environment variable
 """
 
 from dataclasses import dataclass
+import typing
 
 from qtpy import QtCore, QtGui, QtWidgets
 
@@ -33,17 +34,18 @@ class AddEnvironmentDialog(QtWidgets.QDialog):
         self.setAttribute(QtCore.Qt.WA_DeleteOnClose, True)
         self._ui = Ui_AddEnvironmentDialog()
         self._ui.setupUi(self)  # type: ignore[no-untyped-call]
-        conan_environment_menu = QtWidgets.QMenu("Conan environment variables", self)
+        conan_environment_actions: typing.List[QtGui.QAction] = []
         for key, _ in context.get_conan_config_environment_variables().items():
             key_action = QtGui.QAction(key, self)
             key_action.triggered.connect(self._set_name)
-            conan_environment_menu.addAction(key_action)
-        conan_environment_menu.addSeparator()
+            conan_environment_actions.append(key_action)
         # TODO: CONAN_V2_MODE is obsolete
         conan_v2_mode_action = QtGui.QAction("CONAN_V2_MODE", self)
         conan_v2_mode_action.triggered.connect(self._set_name)  # type: ignore
-        conan_environment_menu.addAction(conan_v2_mode_action)
-        self._ui.name.set_custom_menu(conan_environment_menu)
+        conan_environment_actions.append(conan_v2_mode_action)
+        self._ui.name.add_submenu_actions(
+            "Conan environment variables", conan_environment_actions
+        )
         self._ui.name.textChanged.connect(self._updated)
         self._ui.value.textChanged.connect(self._updated)
         self._ui.buttonBox.button(QtWidgets.QDialogButtonBox.Ok).setEnabled(False)

--- a/cruiz/manage_local_cache/widgets/addremotedialog.py
+++ b/cruiz/manage_local_cache/widgets/addremotedialog.py
@@ -28,17 +28,15 @@ class AddRemoteDialog(QtWidgets.QDialog):
         self.setAttribute(QtCore.Qt.WA_DeleteOnClose, True)
         self._ui = Ui_AddRemoteDialog()
         self._ui.setupUi(self)  # type: ignore[no-untyped-call]
-        recent_remotes_menu = QtWidgets.QMenu("Recent remotes", self)
+        recent_remotes_actions: typing.List[QtGui.QAction] = []
         with RecentConanRemotesSettingsReader() as settings:
             recent_remote_urls = settings.urls.resolve()
         if recent_remote_urls:
             for remote in recent_remote_urls:
                 remote_action = QtGui.QAction(remote, self)
                 remote_action.triggered.connect(partial(self._set_remote_url, remote))
-                recent_remotes_menu.addAction(remote_action)
-        else:
-            recent_remotes_menu.setEnabled(False)
-        self._ui.url.set_custom_menu(recent_remotes_menu)
+                recent_remotes_actions.append(remote_action)
+        self._ui.url.add_submenu_actions("Recent remotes", recent_remotes_actions)
         self._ui.url.textChanged.connect(self._updated)
         self._ui.name.textChanged.connect(self._updated)
         self._ui.buttonBox.button(QtWidgets.QDialogButtonBox.Ok).clicked.connect(

--- a/cruiz/manage_local_cache/widgets/configpathorurl.py
+++ b/cruiz/manage_local_cache/widgets/configpathorurl.py
@@ -4,6 +4,8 @@
 QLineEdit subclass that has a custom context menu
 """
 
+import typing
+
 from qtpy import QtGui, QtWidgets
 
 
@@ -12,17 +14,22 @@ class LineEditWithCustomContextMenu(QtWidgets.QLineEdit):
     Subclass allowing a custom context menu to be appended to the standard menu.
     """
 
-    def set_custom_menu(self, menu: QtWidgets.QMenu) -> None:
+    def add_submenu_actions(
+        self, submenu_name: str, actions: typing.List[QtGui.QAction]
+    ) -> None:
         """
-        Set the custom menu on this widget
+        Provide the name of a submenu and the QActions for it
         """
-        # pylint: disable=attribute-defined-outside-init
-        self._custom_menu = menu
+        self._submenu_name = submenu_name
+        self._submenu_actions = actions
 
     def contextMenuEvent(self, event: QtGui.QContextMenuEvent) -> None:
         menu = self.createStandardContextMenu()
-        if self._custom_menu:
-            menu.addSeparator()
-            self._custom_menu.setParent(menu)
-            menu.addMenu(self._custom_menu)
+        menu.addSeparator()
+        submenu = menu.addMenu(self._submenu_name)
+        if self._submenu_actions:
+            submenu.addActions(self._submenu_actions)
+        else:
+            submenu.setEnabled(False)
+
         menu.exec_(event.globalPos())

--- a/cruiz/manage_local_cache/widgets/installconfigdialog.py
+++ b/cruiz/manage_local_cache/widgets/installconfigdialog.py
@@ -33,17 +33,17 @@ class InstallConfigDialog(QtWidgets.QDialog):
         self._ui = Ui_InstallConfigDialog()
         self._ui.setupUi(self)  # type: ignore[no-untyped-call]
         self._context = context
-        recent_config_paths_menu = QtWidgets.QMenu("Recent config paths", self)
+        recent_config_paths_actions: typing.List[QtGui.QAction] = []
         with RecentConanConfigSettingsReader() as settings:
             config_paths = settings.paths.resolve()
         if config_paths:
             for path in config_paths:
                 path_action = QtGui.QAction(path, self)
                 path_action.triggered.connect(partial(self._set_url, path))
-                recent_config_paths_menu.addAction(path_action)
-        else:
-            recent_config_paths_menu.setEnabled(False)
-        self._ui.pathOrUrl.set_custom_menu(recent_config_paths_menu)
+                recent_config_paths_actions.append(path_action)
+        self._ui.pathOrUrl.add_submenu_actions(
+            "Recent config paths", recent_config_paths_actions
+        )
         self._ui.pathOrUrl.textChanged.connect(self._path_updated)
         self._ui.installButton.setEnabled(False)
         self._ui.installButton.clicked.connect(self._install)


### PR DESCRIPTION
Implemented adding custom context submenus in a different way to avoid
- the Linux warning about parentage
- QActions overwriting in the parent context menu