### PR TITLE
Fixes #62. Simple way to specify dependency options

### DIFF
--- a/cruiz/interop/commandparameters.py
+++ b/cruiz/interop/commandparameters.py
@@ -57,6 +57,7 @@ class CommandParameters(CommonParameters):
         self._time_commands: typing.Optional[bool] = None
         self._v2_omit_test_folder: typing.Optional[bool] = None
         self._v2_needs_reference: typing.Optional[bool] = None
+        self._extra_options: typing.Optional[str] = None
 
     def to_args(self) -> typing.List[str]:
         """
@@ -400,12 +401,18 @@ class CommandParameters(CommonParameters):
         """
         return self._options
 
-    def add_option(self, package_name: str, key: str, value: str) -> None:
+    def add_option(
+        self, package_name: typing.Optional[str], key: str, value: str
+    ) -> None:
         """
         Add an option key-value pair.
+        If package_name is provided, the option key is prefixed with package_name:
         """
         assert key not in self._options
-        self._options[f"{package_name}:{key}"] = value
+        if package_name:
+            self._options[f"{package_name}:{key}"] = value
+        else:
+            self._options[key] = value
 
     @property
     def force(self) -> typing.Optional[bool]:
@@ -500,3 +507,15 @@ class CommandParameters(CommonParameters):
     @v2_need_reference.setter
     def v2_need_reference(self, value: typing.Optional[bool]) -> None:
         self._v2_needs_reference = value
+
+    @property
+    def extra_options(self) -> typing.Optional[str]:
+        """
+        Get the extra options string.
+        May be None.
+        """
+        return self._extra_options
+
+    @extra_options.setter
+    def extra_options(self, value: typing.Optional[str]) -> None:
+        self._extra_options = value

--- a/cruiz/recipe/recipewidget.py
+++ b/cruiz/recipe/recipewidget.py
@@ -258,7 +258,7 @@ class RecipeWidget(QtWidgets.QMainWindow):
             self._local_workflow_expression_editor
         )
         extra_option_list_regex = QtCore.QRegularExpression(
-            # of the form <pkg>:<option>=<value,[<repeat>]
+            # of the form <pkg>:<option>=<value>[,<repeat>]
             r"^$|^([^:=,\s]+:[^=,\s]+=[^,\s]+)(\s*,\s*[^:=,\s]+:[^=,\s]+=[^,\s]+)*$"
         )
         extra_option_list_validator = QtGui.QRegularExpressionValidator(

--- a/cruiz/recipe/toolbars/command.py
+++ b/cruiz/recipe/toolbars/command.py
@@ -392,6 +392,11 @@ class RecipeCommandToolbar(QtWidgets.QToolBar):
                     params.add_option(
                         recipe_attributes["name"], key, value
                     )  # TODO: is this the most efficient algorithm?
+                attributes = settings.attribute_overrides.resolve()
+                if "extra_config_options" in attributes:
+                    for keyvalue in attributes["extra_config_options"].split(","):
+                        option_name, option_value = keyvalue.split("=")
+                        params.add_option(None, option_name, option_value)
             self._append_build_features(params, settings)
             if with_exclusive_package_folder:
                 # export-pkg requires

--- a/cruiz/resources/recipe_window.ui
+++ b/cruiz/resources/recipe_window.ui
@@ -316,8 +316,8 @@
          <rect>
           <x>0</x>
           <y>0</y>
-          <width>313</width>
-          <height>211</height>
+          <width>312</width>
+          <height>281</height>
          </rect>
         </property>
         <layout class="QVBoxLayout" name="verticalLayout_13">
@@ -349,6 +349,21 @@
             <string>Options</string>
            </property>
            <layout class="QGridLayout" name="optionsLayout"/>
+          </widget>
+         </item>
+         <item>
+          <widget class="QGroupBox" name="groupBox">
+           <property name="toolTip">
+            <string>A comma separated list of &lt;pkg&gt;:&lt;option&gt;=&lt;value&gt;</string>
+           </property>
+           <property name="title">
+            <string>Additional options</string>
+           </property>
+           <layout class="QVBoxLayout" name="verticalLayout_20">
+            <item>
+             <widget class="QLineEdit" name="configureAdditionalOptions"/>
+            </item>
+           </layout>
           </widget>
          </item>
          <item>
@@ -418,7 +433,7 @@
          <rect>
           <x>0</x>
           <y>0</y>
-          <width>328</width>
+          <width>327</width>
           <height>535</height>
          </rect>
         </property>
@@ -633,7 +648,7 @@
          <rect>
           <x>0</x>
           <y>0</y>
-          <width>326</width>
+          <width>214</width>
           <height>531</height>
          </rect>
         </property>


### PR DESCRIPTION
Configuration has a new QLineEdit that takes a string of the form

```
<pkg>:<option>=<value>[,<repeat>]
```

so that option values for dependencies can be incorporated into the build.

The QLineEdit has a validator to ensure the format.

Conan commands that take options, as well as the lockfile generation as part of recipe loading, will automatically use additional options.

This is a (hopefully) short term solution as 'full options' are not yet expressed as part of the UI.