### PR TITLE
Support for PySide 6.6 and Python 3.12

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
     - uses: actions/checkout@v3
       with:
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11"]
+        python-version: ["3.12"]
     steps:
     - uses: actions/checkout@v3
       with:
@@ -74,7 +74,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11"]
+        python-version: ["3.12"]
     steps:
     - uses: actions/checkout@v3
       with:

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ See the documentation at [Read The Docs](https://cruiz.readthedocs.io/).
   - macOS (11.0+)
 - Apple Silicon platforms:
   - macOS (11.0+)
-- Python 3.8-3.11
+- Python 3.8-3.12
 - Conan 1.x (from 1.17.1 onwards) and 2.x (from 2.0.7 onwards)
 
 All other Python dependencies are installed when the package is installed.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,5 +2,5 @@
 requires = [
     "setuptools",
     "wheel",
-    "PySide6>=6.5,<6.6"
+    "PySide6>=6.6,<6.7"
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-PySide6>=6.5,<6.6
+PySide6>=6.6,<6.7
 qtpy>=2.3.0,<2.4
 conan<3
 graphviz>=0.19.1,<1

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -6,4 +6,4 @@ flake8-bugbear
 flake8-simplify
 flake8-use-pathlib
 mypy
-PySide6-stubs @ git+https://github.com/python-qt-tools/PySide6-stubs@1e2a21993ce7f2b55828ac250c96973551f8174f
+PySide6-stubs @ git+https://github.com/python-qt-tools/PySide6-stubs@1b8dccccb0c1cb5163b408ab6d4de1d6581755ff

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -4,6 +4,6 @@ flake8
 flake8-black
 flake8-bugbear
 flake8-simplify
-flake8-use-pathlib
+flake8-use-pathlib; python_version < "3.12"
 mypy
 PySide6-stubs @ git+https://github.com/python-qt-tools/PySide6-stubs@1b8dccccb0c1cb5163b408ab6d4de1d6581755ff

--- a/setup.py
+++ b/setup.py
@@ -152,8 +152,9 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
     ],
-    python_requires=">=3.8, <3.12",
+    python_requires=">=3.8, <3.13",
     project_urls={
         "Documentation": "https://cruiz.readthedocs.io/en/latest/",
         "GitHub": "https://github.com/markfinal/cruiz",

--- a/src/cruiz/workers/utils/colorarma_conversion.py
+++ b/src/cruiz/workers/utils/colorarma_conversion.py
@@ -21,7 +21,7 @@ def convert_from_colorama_to_html(escaped_string: str) -> str:
     if escaped_string.endswith("\n"):
         # last new line is catered for by the HTML block
         escaped_string = escaped_string.rsplit("\n", 1)[0]
-    expr = "(\\x1b\[(\d)+m)"  # ESC[NUMm - find NUM  # noqa: W605
+    expr = r"(\x1b\[(\d)+m)"  # ESC[NUMm - find NUM
     matches = re.findall(expr, escaped_string)
     non_escaped_string = copy.deepcopy(escaped_string)
     style = None


### PR DESCRIPTION
Older version of Python remains at 3.8.

The only thing disabled is one flake8 plugin in 3.12 only which uses removed functionality.