### PR TITLE
Fixes #79. Removed obsolete decode calls after subprocess abstractions

### DIFF
--- a/src/cruiz/workers/api/v1/cmakebuildtool.py
+++ b/src/cruiz/workers/api/v1/cmakebuildtool.py
@@ -55,9 +55,9 @@ def invoke(queue: multiprocessing.Queue[Message], params: CommandParameters) -> 
     ) as process:
         assert process.stdout
         for line in iter(process.stdout.readline, b""):
-            queue.put(Stdout(line.decode("utf-8")))
+            queue.put(Stdout(line))
         assert process.stderr
         for line in iter(process.stderr.readline, b""):
-            queue.put(Stderr(line.decode("utf-8")))
+            queue.put(Stderr(line))
 
         queue.put(Success(process.returncode))

--- a/src/cruiz/workers/api/v2/worker.py
+++ b/src/cruiz/workers/api/v2/worker.py
@@ -46,10 +46,10 @@ def _patch_conan_run(queue: multiprocessing.Queue[Message]) -> None:
             ) as process:
                 assert process.stdout
                 for line in iter(process.stdout.readline, b""):
-                    queue.put(Stdout(line.decode("utf-8")))
+                    queue.put(Stdout(line))
                 assert process.stderr
                 for line in iter(process.stderr.readline, b""):
-                    queue.put(Stderr(line.decode("utf-8")))
+                    queue.put(Stderr(line))
 
             return process.returncode
 


### PR DESCRIPTION
Additional `decodes` that can be removed.