### PR TITLE
Fixes #79. iter() sentinals needed to change to non-bytes since the d…

### DIFF
--- a/src/cruiz/workers/api/v1/cmakebuildtool.py
+++ b/src/cruiz/workers/api/v1/cmakebuildtool.py
@@ -54,10 +54,10 @@ def invoke(queue: multiprocessing.Queue[Message], params: CommandParameters) -> 
         cwd=params.cwd,
     ) as process:
         assert process.stdout
-        for line in iter(process.stdout.readline, b""):
+        for line in iter(process.stdout.readline, ""):
             queue.put(Stdout(line))
         assert process.stderr
-        for line in iter(process.stderr.readline, b""):
+        for line in iter(process.stderr.readline, ""):
             queue.put(Stderr(line))
 
         queue.put(Success(process.returncode))

--- a/src/cruiz/workers/api/v2/worker.py
+++ b/src/cruiz/workers/api/v2/worker.py
@@ -45,10 +45,10 @@ def _patch_conan_run(queue: multiprocessing.Queue[Message]) -> None:
                 cwd=cwd,
             ) as process:
                 assert process.stdout
-                for line in iter(process.stdout.readline, b""):
+                for line in iter(process.stdout.readline, ""):
                     queue.put(Stdout(line))
                 assert process.stderr
-                for line in iter(process.stderr.readline, b""):
+                for line in iter(process.stderr.readline, ""):
                     queue.put(Stderr(line))
 
             return process.returncode


### PR DESCRIPTION
…ata is now encoded

This was causing an infinite loop otherwise, as the calling function (readline()) was being called but the sentinel was never met.