### PR TITLE
Fixes #136 Update Conan API usage that were breaking changes in 2.0.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ See the documentation at [Read The Docs](https://cruiz.readthedocs.io/).
 - Apple Silicon platforms:
   - macOS (11.0+)
 - Python 3.8-3.12
-- Conan 1.x (from 1.17.1 onwards) and 2.x (from 2.0.7 onwards)
+- Conan 1.x (from 1.17.1 onwards) and 2.x (from 2.0.14 onwards)
 
 All other Python dependencies are installed when the package is installed.
 

--- a/src/cruiz/workers/api/v2/meta.py
+++ b/src/cruiz/workers/api/v2/meta.py
@@ -49,16 +49,16 @@ def _interop_get_config(api: typing.Any, key: str) -> typing.Optional[str]:
 
 
 def _interop_profiles_dir(api: typing.Any) -> pathlib.Path:
-    from conan.internal.conan_app import ConanApp
+    from conan.internal.cache.home_paths import HomePaths
 
-    app = ConanApp(api.cache_folder)
-    return pathlib.Path(app.cache.profiles_path)
+    paths = HomePaths(api.cache_folder)
+    return pathlib.Path(paths.profiles_path)
 
 
 def _interop_get_hooks(api: typing.Any) -> typing.List[ConanHook]:
     from conan.internal.conan_app import ConanApp
 
-    app = ConanApp(api.cache_folder)
+    app = ConanApp(api.cache_folder, api.config.global_conf)
 
     hooks_dir = app.cache.hooks_path
 
@@ -97,7 +97,7 @@ def _interop_get_conandata(
 ) -> typing.Dict[str, typing.Any]:
     from conan.internal.conan_app import ConanApp
 
-    app = ConanApp(api.cache_folder)
+    app = ConanApp(api.cache_folder, api.config.global_conf)
     return app.loader._load_data(recipe_path)
 
 
@@ -117,11 +117,9 @@ def _interop_get_config_envvars(api: typing.Any) -> typing.List[str]:
 def _interop_profile_meta(
     api: typing.Any, profile: str
 ) -> typing.Dict[str, typing.Dict[str, typing.Any]]:
-    from conans.client.cache.cache import ClientCache
     from conans.client.profile_loader import ProfileLoader
 
-    cache = ClientCache(api.cache_folder)
-    loader = ProfileLoader(cache)
+    loader = ProfileLoader(api.cache_folder)
     # TODO: using internal method
     profile = loader._load_profile(profile, os.getcwd())
     details: typing.Dict[str, typing.Dict[str, typing.Any]] = {"settings": {}}

--- a/src/cruiz/workers/api/v2/packagebinary.py
+++ b/src/cruiz/workers/api/v2/packagebinary.py
@@ -30,7 +30,7 @@ def invoke(
 
         remote = api.remotes.get(params.remote_name)
         pref = PkgReference.loads(params.reference)
-        app = ConanApp(api.cache_folder)
+        app = ConanApp(api.cache_folder, api.config.global_conf)
         metadata = None
 
         # TODO: using non-public method

--- a/src/cruiz/workers/api/v2/packagedetails.py
+++ b/src/cruiz/workers/api/v2/packagedetails.py
@@ -29,7 +29,7 @@ def invoke(queue: multiprocessing.Queue[Message], params: PackageIdParameters) -
 
         remote = api.remotes.get(params.remote_name)
         ref = RecipeReference.loads(params.reference)
-        app = ConanApp(api.cache_folder)
+        app = ConanApp(api.cache_folder, api.config.global_conf)
 
         # dict of keys of type <class 'conans.model.package_ref.PkgReference'>
         results_dict = app.remote_manager.search_packages(

--- a/src/cruiz/workers/api/v2/packagerevisions.py
+++ b/src/cruiz/workers/api/v2/packagerevisions.py
@@ -32,7 +32,7 @@ def invoke(
 
         remote = api.remotes.get(params.remote_name)
         pref = PkgReference.loads(params.reference)
-        app = ConanApp(api.cache_folder)
+        app = ConanApp(api.cache_folder, api.config.global_conf)
 
         prevs_and_timestamps: typing.List[typing.Dict[str, str]] = []
         for new_ref in app.remote_manager.get_package_revisions_references(

--- a/src/cruiz/workers/api/v2/reciperevisions.py
+++ b/src/cruiz/workers/api/v2/reciperevisions.py
@@ -32,7 +32,7 @@ def invoke(
 
         remote = api.remotes.get(params.remote_name)
         ref = RecipeReference.loads(params.reference)
-        app = ConanApp(api.cache_folder)
+        app = ConanApp(api.cache_folder, api.config.global_conf)
 
         rrevs_and_timestamps: typing.List[typing.Dict[str, str]] = []
         for new_ref in app.remote_manager.get_recipe_revisions_references(ref, remote):


### PR DESCRIPTION
- a new required argument to ConanApp
- moved profiles_path property (and others) from ClientCache to HomePaths
- ProfileLoader __init__ changed from taking ClientCache to the cache folder