### PR TITLE
Fixes #147 Remote browser disallows disabled remotes

### DIFF
--- a/src/cruiz/resources/remote_browser.ui
+++ b/src/cruiz/resources/remote_browser.ui
@@ -60,7 +60,11 @@
             <widget class="QComboBox" name="local_cache_name"/>
            </item>
            <item row="4" column="1">
-            <widget class="QLineEdit" name="search_pattern"/>
+            <widget class="QLineEdit" name="search_pattern">
+             <property name="enabled">
+              <bool>false</bool>
+             </property>
+            </widget>
            </item>
            <item row="2" column="0">
             <widget class="QLabel" name="label_2">


### PR DESCRIPTION
Using a disabled remote resulted in a Conan error, so simply disallow selecting a disabled remote.

If all remotes are disabled in a local cache, then the search pattern is not enabled.