### PR TITLE
Fixes #146 Determine Conan location via import mechanisms rather than…

### DIFF
--- a/src/cruiz/globals.py
+++ b/src/cruiz/globals.py
@@ -10,6 +10,7 @@ import typing
 
 CRUIZ_MAINWINDOW: typing.Optional[cruiz.MainWindow] = None  # type: ignore # noqa: F821
 
+CONAN_FULL_VERSION: str = "undetermined"
 CONAN_MAJOR_VERSION: int = 0
 
 CRUIZ_THEME: typing.Optional[str] = None
@@ -44,13 +45,11 @@ def __capture_conan_version() -> None:
     if CONAN_MAJOR_VERSION > 0:
         return
 
-    import cruiz.runcommands
+    import importlib.metadata
 
-    get_conan_version = cruiz.runcommands.run_get_output(["conan", "--version"])
-    version = get_conan_version.replace("Conan version ", "").strip()
-    if not version:
-        raise ValueError("Unable to determine Conan version")
-    version_components = version.split(".")
+    global CONAN_FULL_VERSION
+    CONAN_FULL_VERSION = importlib.metadata.version("conan")
+    version_components = CONAN_FULL_VERSION.split(".")
     CONAN_MAJOR_VERSION = int(version_components[0])
 
 

--- a/src/cruiz/mainwindow.py
+++ b/src/cruiz/mainwindow.py
@@ -7,6 +7,7 @@ The Qt main window of the application
 from __future__ import annotations
 
 from functools import partial
+import importlib.util
 import logging
 import os
 import pathlib
@@ -619,18 +620,18 @@ Remove from the recent list?",
                 self._buildcache_label,
             )
 
+        def get_conan_location() -> str:
+            spec = importlib.util.find_spec("conan")
+            assert spec is not None
+            assert spec.origin is not None
+            return os.fspath(pathlib.Path(spec.origin).parent)
+
         def get_conan_version_output(path: str) -> str:
-            try:
-                # can fail the first time, if a migration of settings in the
-                # local cache fails
-                return cruiz.runcommands.run_get_combined_output([path, "--version"])
-            except subprocess.CalledProcessError:
-                # second time is after the migration, so will work
-                return cruiz.runcommands.run_get_combined_output([path, "--version"])
+            return cruiz.globals.CONAN_FULL_VERSION
 
         statusbar_tool(
             "conan",
-            QtCore.QStandardPaths.findExecutable("conan"),
+            get_conan_location(),
             get_conan_version_output,
             self._conan_label,
         )


### PR DESCRIPTION
… the PATH

For example, using pipx, the conan executable may be visible via the PATH but is not the imported package that cruiz uses.

cruiz no longer assumes it can see the conan executable, which was never used to execute commands anyway, and instead just uses conan as an imported package.

Wrote the arbitrary command in Conan2 to use the usual entry point for the conan package, to avoid calling the executable.