### PR TITLE
Fixes #128 Load toolbar icons even in failing to load recipe scenarios

### DIFF
--- a/src/cruiz/recipe/recipewidget.py
+++ b/src/cruiz/recipe/recipewidget.py
@@ -1191,6 +1191,8 @@ class RecipeWidget(QtWidgets.QMainWindow):
         self._ui.buildFeaturesToolbar.setEnabled(False)
         self._ui.commandToolbar.disable_all_actions()
         self.setWindowTitle(f"Failed to load recipe {self.recipe.path}")
+        # ensure that toolbar icons are loaded, even if the tooltips are wrong
+        self._update_toolbars({})
 
     def _command_started(self) -> None:
         self._busy_icon.setMaximum(0)

--- a/src/cruiz/recipe/toolbars/command.py
+++ b/src/cruiz/recipe/toolbars/command.py
@@ -410,9 +410,11 @@ class RecipeCommandToolbar(QtWidgets.QToolBar):
         if with_recipe_path:
             params.recipe_path = recipe.path
         if with_explicit_name:
-            params.name = recipe_attributes["name"]
+            params.name = recipe_attributes.get("name", "unknown-name")
         if with_pkgref:
-            params.version = recipe.version or recipe_attributes["version"]
+            params.version = recipe.version or recipe_attributes.get(
+                "version", "unknown-version"
+            )
             params.user = recipe.user
             params.channel = recipe.channel
             params.make_package_reference()  # only needed for the exported string


### PR DESCRIPTION
The toolbar icons previously only loaded when a recipe loaded successfully because it was tied to the shortcut creation that needed recipe attribute queries to succeed.

In a recipe failure to load scenario, now try to load the toolbar icons properly but the tooltips may be wrong.