### PR TITLE
Ambiguous option values

### DIFF
--- a/src/cruiz/recipe/recipewidget.py
+++ b/src/cruiz/recipe/recipewidget.py
@@ -257,9 +257,17 @@ class RecipeWidget(QtWidgets.QMainWindow):
         self._ui.localWorkflowExpressionEditor.clicked.connect(
             self._local_workflow_expression_editor
         )
+        empty_regex = r"^$"
+        pkgname_regex = r"[^:=,\s]+"
+        option_name_regex = r"[^=,\s]+"
+        option_value_regex = r"[^,\s]+"
+        qualified_pkg_optionvalue = (
+            f"{pkgname_regex}:{option_name_regex}={option_value_regex}"
+        )
+        comma_separated_regex = r"\s*,\s*"
         extra_option_list_regex = QtCore.QRegularExpression(
             # of the form <pkg>:<option>=<value>[,<repeat>]
-            r"^$|^([^:=,\s]+:[^=,\s]+=[^,\s]+)(\s*,\s*[^:=,\s]+:[^=,\s]+=[^,\s]+)*$"
+            rf"{empty_regex}|^({qualified_pkg_optionvalue})({comma_separated_regex}{qualified_pkg_optionvalue})*$"  # noqa: E501
         )
         extra_option_list_validator = QtGui.QRegularExpressionValidator(
             extra_option_list_regex, self

--- a/src/cruiz/recipe/recipewidget.py
+++ b/src/cruiz/recipe/recipewidget.py
@@ -1114,7 +1114,7 @@ class RecipeWidget(QtWidgets.QMainWindow):
             attributes = settings.attribute_overrides.resolve()
             if "extra_config_options" in attributes:
                 for keyvalue in attributes["extra_config_options"].split(","):
-                    option_name, option_value = keyvalue.split("=")
+                    option_name, option_value = keyvalue.split("=", maxsplit=1)
                     params.add_option(None, option_name, option_value)
         self._dependency_generate_context.conancommand(
             params,

--- a/src/cruiz/recipe/toolbars/command.py
+++ b/src/cruiz/recipe/toolbars/command.py
@@ -439,7 +439,7 @@ class RecipeCommandToolbar(QtWidgets.QToolBar):
                 attributes = settings.attribute_overrides.resolve()
                 if "extra_config_options" in attributes:
                     for keyvalue in attributes["extra_config_options"].split(","):
-                        option_name, option_value = keyvalue.split("=")
+                        option_name, option_value = keyvalue.split("=", maxsplit=1)
                         params.add_option(None, option_name, option_value)
             self._append_build_features(params, settings)
             if with_exclusive_package_folder:


### PR DESCRIPTION
1) don't split a pkgname:optionname=value expression more than once on an equals sign
2) disambiguate the regex in use for future maintenance