### PR TITLE
Fixes #162 Ensure newer Conan 2 versions are supported

### DIFF
--- a/src/cruiz/workers/api/v2/meta.py
+++ b/src/cruiz/workers/api/v2/meta.py
@@ -96,7 +96,11 @@ def _interop_get_conandata(
 ) -> typing.Dict[str, typing.Any]:
     from conan.internal.conan_app import ConanApp
 
-    app = ConanApp(api.cache_folder, api.config.global_conf)
+    try:
+        app = ConanApp(api)
+    except TypeError:
+        # older than v2.1.0
+        app = ConanApp(api.cache_folder, api.config.global_conf)
     return app.loader._load_data(recipe_path)
 
 

--- a/src/cruiz/workers/api/v2/meta.py
+++ b/src/cruiz/workers/api/v2/meta.py
@@ -30,7 +30,11 @@ def _interop_remote_list(api: typing.Any) -> typing.List[ConanRemote]:
 
 
 def _interop_remotes_sync(api: typing.Any, remotes: typing.List[str]) -> None:
-    from conans.client.cache.remote_registry import Remote
+    try:
+        from conan.api.model import Remote
+    except ImportError:
+        # older than v2.1.0
+        from conans.client.cache.remote_registry import Remote
 
     for remote in _interop_remote_list(api):
         api.remotes.remove(remote.name)

--- a/src/cruiz/workers/api/v2/packagebinary.py
+++ b/src/cruiz/workers/api/v2/packagebinary.py
@@ -30,7 +30,11 @@ def invoke(
 
         remote = api.remotes.get(params.remote_name)
         pref = PkgReference.loads(params.reference)
-        app = ConanApp(api.cache_folder, api.config.global_conf)
+        try:
+            app = ConanApp(api)
+        except TypeError:
+            # older than v2.1.0
+            app = ConanApp(api.cache_folder, api.config.global_conf)
         metadata = None
 
         # TODO: using non-public method

--- a/src/cruiz/workers/api/v2/packagedetails.py
+++ b/src/cruiz/workers/api/v2/packagedetails.py
@@ -29,7 +29,11 @@ def invoke(queue: multiprocessing.Queue[Message], params: PackageIdParameters) -
 
         remote = api.remotes.get(params.remote_name)
         ref = RecipeReference.loads(params.reference)
-        app = ConanApp(api.cache_folder, api.config.global_conf)
+        try:
+            app = ConanApp(api)
+        except TypeError:
+            # older than v2.1.0
+            app = ConanApp(api.cache_folder, api.config.global_conf)
 
         # dict of keys of type <class 'conans.model.package_ref.PkgReference'>
         results_dict = app.remote_manager.search_packages(

--- a/src/cruiz/workers/api/v2/packagerevisions.py
+++ b/src/cruiz/workers/api/v2/packagerevisions.py
@@ -32,7 +32,11 @@ def invoke(
 
         remote = api.remotes.get(params.remote_name)
         pref = PkgReference.loads(params.reference)
-        app = ConanApp(api.cache_folder, api.config.global_conf)
+        try:
+            app = ConanApp(api)
+        except TypeError:
+            # older than v2.1.0
+            app = ConanApp(api.cache_folder, api.config.global_conf)
 
         prevs_and_timestamps: typing.List[typing.Dict[str, str]] = []
         for new_ref in app.remote_manager.get_package_revisions_references(

--- a/src/cruiz/workers/api/v2/reciperevisions.py
+++ b/src/cruiz/workers/api/v2/reciperevisions.py
@@ -32,7 +32,11 @@ def invoke(
 
         remote = api.remotes.get(params.remote_name)
         ref = RecipeReference.loads(params.reference)
-        app = ConanApp(api.cache_folder, api.config.global_conf)
+        try:
+            app = ConanApp(api)
+        except TypeError:
+            # older than v2.1.0
+            app = ConanApp(api.cache_folder, api.config.global_conf)
 
         rrevs_and_timestamps: typing.List[typing.Dict[str, str]] = []
         for new_ref in app.remote_manager.get_recipe_revisions_references(ref, remote):


### PR DESCRIPTION
There were some API breaking changes in v2.1.0 that required some updates.