### PR TITLE
Fixes #183 Enable type annotation checks on tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -159,4 +159,5 @@ setup(
         "Documentation": "https://cruiz.readthedocs.io/en/latest/",
         "GitHub": "https://github.com/markfinal/cruiz",
     },
+    package_data={"cruiz": ["py.typed"]},
 )

--- a/src/cruiz/resourcegeneration.py
+++ b/src/cruiz/resourcegeneration.py
@@ -7,7 +7,6 @@ Resource generation from PySide
 import logging
 import os
 import pathlib
-import sys
 import typing
 
 import cruiz.runcommands
@@ -75,6 +74,3 @@ def generate_resources() -> None:
     logger.debug("Checking for out-of-date resources...")
     _ensure_resource_file_is_up_to_date(current_dir / SUBDIR, resources_dir)
     _ensure_ui_files_are_up_to_date(current_dir / SUBDIR, resources_dir)
-    if "CRUIZ_GENERATE_RESOURCES_ONLY" in os.environ:
-        print("Completed resource generation...exiting")
-        sys.exit(0)

--- a/src/cruiz/version.py
+++ b/src/cruiz/version.py
@@ -11,11 +11,12 @@ after the last annotated tag.
 def get_version() -> str:
     """
     Try to get a fixed version number from the RELEASE_VERSION module (written by
-    binary distributions).
+    source and binary distributions).
     Otherwise, fallback to accessing Git information.
     """
     try:
-        from .RELEASE_VERSION import __version__  # type: ignore[import-untyped]
+        # in an editable install, RELEASE_VERSION does not exist
+        from .RELEASE_VERSION import __version__
 
         return __version__
     except ImportError:

--- a/tests/interop/test_pod.py
+++ b/tests/interop/test_pod.py
@@ -4,7 +4,7 @@ import urllib.parse
 from cruiz.interop.pod import ConanHook
 
 
-def test_pod_hook_invariant_after_serialization():
+def test_pod_hook_invariant_after_serialization() -> None:
     """
     ConanHook objects are passed over multiprocessing via encoded URLs
     which need to be deserialized in the child process.

--- a/tox.ini
+++ b/tox.ini
@@ -9,14 +9,11 @@ testpaths =
     tests
 
 [testenv:lint]
-setenv =
-    CRUIZ_GENERATE_RESOURCES_ONLY = 1
 deps =
     -r{toxinidir}/requirements_dev.txt
     -r{toxinidir}/requirements.txt
 commands =
-    pip install -e .
-    python -m cruiz
+    pip install .
     flake8 src/cruiz
     flake8 tests
     mypy --install-types --non-interactive src/cruiz
@@ -27,5 +24,5 @@ deps =
     -r{toxinidir}/requirements_dev.txt
     -r{toxinidir}/requirements.txt
 commands =
-    pip install -e .
+    pip install .
     pytest

--- a/tox.ini
+++ b/tox.ini
@@ -17,8 +17,10 @@ deps =
 commands =
     pip install -e .
     python -m cruiz
-    flake8 src/cruiz tests
+    flake8 src/cruiz
+    flake8 tests
     mypy --install-types --non-interactive src/cruiz
+    mypy --install-types --non-interactive tests
 
 [testenv:test]
 deps =


### PR DESCRIPTION
This adds the py.typed marker file.

It fixes missing type annotations in the current tests.

It simplifies the install of cruiz for testing in tox, so that all required files are generated in the tox environment, and doesn't require a special case to need to run cruiz and early out after resource generation.
