### PR TITLE
Fixes #205 Canonicalise Python import orders

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -7,6 +7,7 @@ flake8-simplify
 flake8-use-pathlib; python_version < "3.12"
 flake8-pyproject
 flake8-type-checking
+flake8-import-order
 mypy
 types-colorama
 types-six

--- a/src/cruiz/__main__.py
+++ b/src/cruiz/__main__.py
@@ -6,6 +6,7 @@ cruiz: Conan recipe user interface
 
 import os
 
+from cruiz.entrypoint import main
 from cruiz.resourcegeneration import generate_resources
 
 # resource generation be invoked before resources and MainWindow are imported
@@ -13,8 +14,6 @@ generate_resources()
 
 
 os.environ.setdefault("QT_API", "pyside6")
-
-from cruiz.entrypoint import main  # noqa: E402
 
 
 if __name__ == "__main__":

--- a/src/cruiz/application.py
+++ b/src/cruiz/application.py
@@ -8,10 +8,10 @@ from __future__ import annotations
 
 import typing
 
-from qtpy import QtCore, QtGui, QtWidgets
-
 from cruiz.settings.ensuredefaultlocalcache import ensure_default_local_cache
 from cruiz.settings.managers.fontpreferences import FontSettingsReader, FontUsage
+
+from qtpy import QtCore, QtGui, QtWidgets
 
 
 class Application(QtWidgets.QApplication):

--- a/src/cruiz/commands/conanenv.py
+++ b/src/cruiz/commands/conanenv.py
@@ -8,7 +8,6 @@ import logging
 import typing
 
 import cruiz.globals
-
 from cruiz.settings.managers.conanpreferences import ConanSettingsReader
 from cruiz.settings.managers.namedlocalcache import NamedLocalCacheSettingsReader
 

--- a/src/cruiz/commands/conaninvocation.py
+++ b/src/cruiz/commands/conaninvocation.py
@@ -15,11 +15,11 @@ import sys
 import threading
 import typing
 
+from cruiz.settings.managers.generalpreferences import GeneralSettingsReader
+
 import psutil
 
 from qtpy import QtCore, QtWidgets
-
-from cruiz.settings.managers.generalpreferences import GeneralSettingsReader
 
 from .messagereplyprocessor import MessageReplyProcessor
 

--- a/src/cruiz/commands/context.py
+++ b/src/cruiz/commands/context.py
@@ -6,27 +6,23 @@ A context object wrapping the Conan API
 
 from __future__ import annotations
 
-from contextlib import contextmanager
 import logging
 import pathlib
 import typing
+from contextlib import contextmanager
+
+import cruiz.workers.api as workers_api
+from cruiz.constants import DEFAULT_CACHE_NAME
+from cruiz.exceptions import RecipeInspectionError
+from cruiz.interop.commandparameters import CommandParameters
+from cruiz.recipe.logs.command import CommandListWidgetItem, RecipeCommandHistoryWidget
+from cruiz.settings.managers.namedlocalcache import NamedLocalCacheSettingsReader
 
 from qtpy import QtCore, QtWidgets
 
-from cruiz.exceptions import RecipeInspectionError
-
-from cruiz.interop.commandparameters import CommandParameters
-from cruiz.recipe.logs.command import CommandListWidgetItem
-from cruiz.settings.managers.namedlocalcache import NamedLocalCacheSettingsReader
-
-import cruiz.workers.api as workers_api
-
-from cruiz.recipe.logs.command import RecipeCommandHistoryWidget
-from cruiz.constants import DEFAULT_CACHE_NAME
-
+from .conanenv import get_conan_env
 from .conaninvocation import ConanInvocation
 from .metarequestconaninvocation import MetaRequestConanInvocation
-from .conanenv import get_conan_env
 
 if typing.TYPE_CHECKING:
     from cruiz.interop.packagenode import PackageNode

--- a/src/cruiz/commands/messagereplyprocessor.py
+++ b/src/cruiz/commands/messagereplyprocessor.py
@@ -12,20 +12,19 @@ import multiprocessing
 import sys
 import typing
 
-from qtpy import QtCore
-
-from cruiz.dumpobjecttypes import dump_object_types
-
 import cruiz.workers.api as workers_api
+from cruiz.dumpobjecttypes import dump_object_types
 from cruiz.interop.message import (
-    Message,
-    End,
-    Stdout,
-    Stderr,
-    Success,
-    Failure,
     ConanLogMessage,
+    End,
+    Failure,
+    Message,
+    Stderr,
+    Stdout,
+    Success,
 )
+
+from qtpy import QtCore
 
 logger = logging.getLogger(__name__)
 

--- a/src/cruiz/commands/metarequestconaninvocation.py
+++ b/src/cruiz/commands/metarequestconaninvocation.py
@@ -14,18 +14,18 @@ import sys
 import typing
 import urllib.parse
 
-from qtpy import QtCore
-
-from cruiz.interop.commandparameters import CommandParameters
-from cruiz.interop.message import (
-    Success,
-    Failure,
-    Stdout,
-    Stderr,
-    ConanLogMessage,
-)
 import cruiz.workers.api as workers_api
 from cruiz.dumpobjecttypes import dump_object_types
+from cruiz.interop.commandparameters import CommandParameters
+from cruiz.interop.message import (
+    ConanLogMessage,
+    Failure,
+    Stderr,
+    Stdout,
+    Success,
+)
+
+from qtpy import QtCore
 
 from .conanenv import get_conan_env
 

--- a/src/cruiz/entrypoint.py
+++ b/src/cruiz/entrypoint.py
@@ -36,8 +36,7 @@ logging.basicConfig(
 
 logger = logging.getLogger(__name__)
 
-import cruiz.pyside6.resources  # noqa: F401, E402
-
+import cruiz.pyside6.resources  # noqa: F401, E402, I100
 from cruiz.application import Application  # noqa: E402
 from cruiz.mainwindow import MainWindow  # noqa: E402
 from cruiz.settings.updatesettings import (  # noqa: E402

--- a/src/cruiz/globals.py
+++ b/src/cruiz/globals.py
@@ -6,6 +6,7 @@ Global variables
 """
 
 from __future__ import annotations
+
 import typing
 
 CRUIZ_MAINWINDOW: typing.Optional[cruiz.MainWindow] = None  # type: ignore # noqa: F821

--- a/src/cruiz/interop/commandparameters.py
+++ b/src/cruiz/interop/commandparameters.py
@@ -6,9 +6,9 @@ Conan command parameters
 
 from __future__ import annotations
 
-from io import StringIO
 import pathlib
 import typing
+from io import StringIO
 
 import cruiz.globals
 

--- a/src/cruiz/interop/commonparameters.py
+++ b/src/cruiz/interop/commonparameters.py
@@ -4,8 +4,8 @@
 Common parameters
 """
 
-from dataclasses import dataclass, field
 import typing
+from dataclasses import dataclass, field
 
 
 @dataclass

--- a/src/cruiz/interop/dependencygraph.py
+++ b/src/cruiz/interop/dependencygraph.py
@@ -6,8 +6,8 @@ Interop between Conan and cruiz
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 import typing
+from dataclasses import dataclass
 
 if typing.TYPE_CHECKING:
     from .packagenode import PackageNode

--- a/src/cruiz/interop/packagenode.py
+++ b/src/cruiz/interop/packagenode.py
@@ -6,8 +6,8 @@ Interop between Conan and cruiz
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
 import typing
+from dataclasses import dataclass, field
 
 
 @dataclass

--- a/src/cruiz/interop/pod.py
+++ b/src/cruiz/interop/pod.py
@@ -6,9 +6,9 @@ Plain old data classes
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
 import pathlib
 import typing
+from dataclasses import dataclass, field
 
 
 # copied from distutils.url.strtobool and modified

--- a/src/cruiz/load_recipe/loadrecipewizard.py
+++ b/src/cruiz/load_recipe/loadrecipewizard.py
@@ -9,18 +9,15 @@ from __future__ import annotations
 import pathlib
 import typing
 
-from qtpy import QtCore, QtWidgets
-
-from cruiz.pyside6.load_recipe_wizard import Ui_LoadRecipeWizard
-
-from cruiz.exceptions import RecipeDoesNotExistError, RecipeAlreadyOpenError
-from cruiz.settings.managers.recipe import RecipeSettings, RecipeSettingsReader
-
+import cruiz.globals
 from cruiz.commands.context import managed_conan_context
 from cruiz.commands.logdetails import LogDetails
 from cruiz.constants import DEFAULT_CACHE_NAME
+from cruiz.exceptions import RecipeAlreadyOpenError, RecipeDoesNotExistError
+from cruiz.pyside6.load_recipe_wizard import Ui_LoadRecipeWizard
+from cruiz.settings.managers.recipe import RecipeSettings, RecipeSettingsReader
 
-import cruiz.globals
+from qtpy import QtCore, QtWidgets
 
 if typing.TYPE_CHECKING:
     from cruiz.recipe.recipe import Recipe

--- a/src/cruiz/load_recipe/pages/initialprofilepage.py
+++ b/src/cruiz/load_recipe/pages/initialprofilepage.py
@@ -8,13 +8,12 @@ from __future__ import annotations
 
 import typing
 
-from qtpy import QtWidgets
-
 from cruiz.commands.context import managed_conan_context
 from cruiz.commands.logdetails import LogDetails
-
-from cruiz.widgets.util import BlockSignals
 from cruiz.settings.managers.recipe import RecipeSettingsReader
+from cruiz.widgets.util import BlockSignals
+
+from qtpy import QtWidgets
 
 if typing.TYPE_CHECKING:
     import pathlib

--- a/src/cruiz/load_recipe/pages/localcachepage.py
+++ b/src/cruiz/load_recipe/pages/localcachepage.py
@@ -6,12 +6,12 @@ Wizard page for selecting a local cache
 
 import typing
 
-from qtpy import QtWidgets
-
-from cruiz.widgets.util import BlockSignals
+from cruiz.manage_local_cache import ManageLocalCachesDialog
 from cruiz.settings.managers.namedlocalcache import AllNamedLocalCacheSettingsReader
 from cruiz.settings.managers.recipe import RecipeSettingsReader
-from cruiz.manage_local_cache import ManageLocalCachesDialog
+from cruiz.widgets.util import BlockSignals
+
+from qtpy import QtWidgets
 
 
 class LoadRecipeLocalCachePage(QtWidgets.QWizardPage):

--- a/src/cruiz/load_recipe/pages/packageversionpage.py
+++ b/src/cruiz/load_recipe/pages/packageversionpage.py
@@ -6,13 +6,12 @@ Wizard page for selecting the version of the package
 
 import typing
 
-from qtpy import QtCore, QtGui, QtWidgets
-
-from cruiz.widgets.util import BlockSignals
+import cruiz.globals
 from cruiz.settings.managers.conanpreferences import ConanSettingsReader
 from cruiz.settings.managers.recipe import RecipeSettingsReader
+from cruiz.widgets.util import BlockSignals
 
-import cruiz.globals
+from qtpy import QtCore, QtGui, QtWidgets
 
 
 class LoadRecipePackageVersionPage(QtWidgets.QWizardPage):

--- a/src/cruiz/mainwindow.py
+++ b/src/cruiz/mainwindow.py
@@ -6,7 +6,6 @@ The Qt main window of the application
 
 from __future__ import annotations
 
-from functools import partial
 import importlib.util
 import logging
 import os
@@ -15,49 +14,46 @@ import platform
 import subprocess
 import time
 import typing
+from functools import partial
 
-from qtpy import QtCore, QtGui, QtWidgets
-import psutil
-
+import cruiz.config
+import cruiz.globals
+import cruiz.runcommands
+from cruiz.environ import EnvironSaver
 from cruiz.exceptions import (
     InconsistentSettingsError,
     RecipeAlreadyOpenError,
     RecipeDoesNotExistError,
     RecipeInspectionError,
 )
-
+from cruiz.load_recipe.loadrecipewizard import LoadRecipeWizard
+from cruiz.manage_local_cache import ManageLocalCachesDialog
 from cruiz.recipe.recipewidget import RecipeWidget
+from cruiz.remote_browser.remotebrowser import RemoteBrowserDock
+from cruiz.settings.managers.cmakepreferences import CMakeSettingsReader
+from cruiz.settings.managers.compilercachepreferences import CompilerCacheSettingsReader
+from cruiz.settings.managers.generalpreferences import GeneralSettingsReader
+from cruiz.settings.managers.ninjapreferences import NinjaSettingsReader
+from cruiz.settings.managers.recentrecipes import (
+    RecentRecipeSettingsDeleter,
+    RecentRecipeSettingsReader,
+    RecentRecipeSettingsWriter,
+)
 from cruiz.settings.managers.recipe import (
     RecipeSettings,
+    RecipeSettingsDeleter,
     RecipeSettingsReader,
     RecipeSettingsWriter,
 )
 from cruiz.settings.preferencesdialog import PreferencesDialog
-from cruiz.settings.managers.generalpreferences import GeneralSettingsReader
-from cruiz.settings.managers.recentrecipes import (
-    RecentRecipeSettingsReader,
-    RecentRecipeSettingsWriter,
-    RecentRecipeSettingsDeleter,
-)
-from cruiz.settings.managers.cmakepreferences import CMakeSettingsReader
-from cruiz.settings.managers.ninjapreferences import NinjaSettingsReader
-from cruiz.settings.managers.compilercachepreferences import CompilerCacheSettingsReader
-from cruiz.settings.managers.recipe import RecipeSettingsDeleter
 from cruiz.widgets import (
     AboutDialog,
     log_created_widget,
 )
-from cruiz.manage_local_cache import ManageLocalCachesDialog
 
-from cruiz.environ import EnvironSaver
-from cruiz.remote_browser.remotebrowser import RemoteBrowserDock
+import psutil
 
-from cruiz.load_recipe.loadrecipewizard import LoadRecipeWizard
-
-import cruiz.config
-
-import cruiz.globals
-import cruiz.runcommands
+from qtpy import QtCore, QtGui, QtWidgets
 
 logger = logging.getLogger(__name__)
 

--- a/src/cruiz/manage_local_cache/managelocalcachesdialog.py
+++ b/src/cruiz/manage_local_cache/managelocalcachesdialog.py
@@ -5,27 +5,28 @@ Dialog for managing local caches
 """
 
 import dataclasses
-from enum import IntEnum
 import os
 import pathlib
 import platform
 import shutil
 import stat
 import typing
-
-from qtpy import QtCore, QtGui, QtWidgets
+from enum import IntEnum
 
 import cruiz.globals
-
+from cruiz.commands.conanconf import ConanConfigBoolean
+from cruiz.commands.context import ConanContext
 from cruiz.commands.logdetails import LogDetails
-
+from cruiz.constants import DEFAULT_CACHE_NAME
 from cruiz.interop.pod import ConanHook
+from cruiz.pyside6.local_cache_manage import Ui_ManageLocalCaches
+from cruiz.revealonfilesystem import reveal_on_filesystem
 from cruiz.settings.managers.namedlocalcache import (
+    AllNamedLocalCacheSettingsReader,
+    NamedLocalCacheDeleter,
     NamedLocalCacheSettings,
     NamedLocalCacheSettingsReader,
     NamedLocalCacheSettingsWriter,
-    AllNamedLocalCacheSettingsReader,
-    NamedLocalCacheDeleter,
     _EnvChangeManagement,
 )
 from cruiz.settings.managers.recentconanremotes import (
@@ -33,24 +34,19 @@ from cruiz.settings.managers.recentconanremotes import (
     RecentConanRemotesSettingsWriter,
 )
 from cruiz.widgets.util import BlockSignals
-from cruiz.commands.context import ConanContext
-from cruiz.commands.conanconf import ConanConfigBoolean
 
-from cruiz.revealonfilesystem import reveal_on_filesystem
-from cruiz.constants import DEFAULT_CACHE_NAME
-
-from cruiz.pyside6.local_cache_manage import Ui_ManageLocalCaches
+from qtpy import QtCore, QtGui, QtWidgets
 
 from .widgets import (
-    NewLocalCacheWizard,
+    AddEnvironmentDialog,
+    AddExtraProfileDirectoryDialog,
+    AddRemoteDialog,
     InstallConfigDialog,
     MoveLocalCacheDialog,
-    AddRemoteDialog,
-    RemoveLocksDialog,
+    NewLocalCacheWizard,
     RemoveAllPackagesDialog,
-    AddExtraProfileDirectoryDialog,
-    AddEnvironmentDialog,
     RemoveEnvironmentDialog,
+    RemoveLocksDialog,
     RunConanCommandDialog,
 )
 

--- a/src/cruiz/manage_local_cache/widgets/__init__.py
+++ b/src/cruiz/manage_local_cache/widgets/__init__.py
@@ -4,17 +4,17 @@
 Conan manage local cache widgets
 """
 
-from .newlocalcachewizard import NewLocalCacheWizard as NewLocalCacheWizard
-from .installconfigdialog import InstallConfigDialog as InstallConfigDialog
-from .movelocalcachedialog import MoveLocalCacheDialog as MoveLocalCacheDialog
-from .addremotedialog import AddRemoteDialog as AddRemoteDialog
-from .progressdialogs import (
-    RemoveLocksDialog as RemoveLocksDialog,
-    RemoveAllPackagesDialog as RemoveAllPackagesDialog,
-)
+from .addenvironmentdialog import AddEnvironmentDialog as AddEnvironmentDialog
 from .addextraprofiledirectorydialog import (
     AddExtraProfileDirectoryDialog as AddExtraProfileDirectoryDialog,
 )
-from .addenvironmentdialog import AddEnvironmentDialog as AddEnvironmentDialog
-from .runconancommanddialog import RunConanCommandDialog as RunConanCommandDialog
+from .addremotedialog import AddRemoteDialog as AddRemoteDialog
+from .installconfigdialog import InstallConfigDialog as InstallConfigDialog
+from .movelocalcachedialog import MoveLocalCacheDialog as MoveLocalCacheDialog
+from .newlocalcachewizard import NewLocalCacheWizard as NewLocalCacheWizard
+from .progressdialogs import (
+    RemoveAllPackagesDialog as RemoveAllPackagesDialog,
+    RemoveLocksDialog as RemoveLocksDialog,
+)
 from .removeenvironmentdialog import RemoveEnvironmentDialog as RemoveEnvironmentDialog
+from .runconancommanddialog import RunConanCommandDialog as RunConanCommandDialog

--- a/src/cruiz/manage_local_cache/widgets/addenvironmentdialog.py
+++ b/src/cruiz/manage_local_cache/widgets/addenvironmentdialog.py
@@ -6,14 +6,13 @@ Dialog for adding an environment variable
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 import typing
-
-from qtpy import QtCore, QtGui, QtWidgets
+from dataclasses import dataclass
 
 import cruiz.globals
-
 from cruiz.pyside6.local_cache_add_environment import Ui_AddEnvironmentDialog
+
+from qtpy import QtCore, QtGui, QtWidgets
 
 if typing.TYPE_CHECKING:
     from cruiz.commands.context import ConanContext

--- a/src/cruiz/manage_local_cache/widgets/addextraprofiledirectorydialog.py
+++ b/src/cruiz/manage_local_cache/widgets/addextraprofiledirectorydialog.py
@@ -6,14 +6,13 @@ Dialog for adding extra profile directories
 
 import typing
 
-from qtpy import QtCore, QtGui, QtWidgets
-
 from cruiz.interop.pod import ExtraProfileDirectory
-from cruiz.widgets.util import search_for_dir_options
-
 from cruiz.pyside6.local_cache_add_profile_directory import (
     Ui_AddExtraProfileDirectoryDialog,
 )
+from cruiz.widgets.util import search_for_dir_options
+
+from qtpy import QtCore, QtGui, QtWidgets
 
 
 class AddExtraProfileDirectoryDialog(QtWidgets.QDialog):

--- a/src/cruiz/manage_local_cache/widgets/addremotedialog.py
+++ b/src/cruiz/manage_local_cache/widgets/addremotedialog.py
@@ -4,18 +4,16 @@
 Dialog for adding a new remote.
 """
 
-from functools import partial
 import typing
+from functools import partial
+
+from cruiz.interop.pod import ConanRemote
+from cruiz.pyside6.local_cache_add_remote import Ui_AddRemoteDialog
+from cruiz.settings.managers.recentconanremotes import RecentConanRemotesSettingsReader
 
 from qtpy import QtCore, QtGui, QtWidgets
 
 import validators
-
-from cruiz.interop.pod import ConanRemote
-
-from cruiz.settings.managers.recentconanremotes import RecentConanRemotesSettingsReader
-
-from cruiz.pyside6.local_cache_add_remote import Ui_AddRemoteDialog
 
 
 class AddRemoteDialog(QtWidgets.QDialog):

--- a/src/cruiz/manage_local_cache/widgets/installconfigdialog.py
+++ b/src/cruiz/manage_local_cache/widgets/installconfigdialog.py
@@ -6,21 +6,19 @@ Dialog for installing a new Conan config
 
 from __future__ import annotations
 
-from functools import partial
 import typing
+from functools import partial
 
-from qtpy import QtCore, QtGui, QtWidgets
-
+import cruiz.workers.api as workers_api
 from cruiz.interop.commandparameters import CommandParameters
-
 from cruiz.pyside6.local_cache_install_config import Ui_InstallConfigDialog
-
 from cruiz.settings.managers.recentconanconfigs import (
-    RecentConanConfigSettingsReader,
     RecentConanConfigSettings,
+    RecentConanConfigSettingsReader,
     RecentConanConfigSettingsWriter,
 )
-import cruiz.workers.api as workers_api
+
+from qtpy import QtCore, QtGui, QtWidgets
 
 if typing.TYPE_CHECKING:
     from cruiz.commands.context import ConanContext

--- a/src/cruiz/manage_local_cache/widgets/keyvaluetable.py
+++ b/src/cruiz/manage_local_cache/widgets/keyvaluetable.py
@@ -6,9 +6,9 @@ Widget for a table of key-value pairs
 
 from enum import IntEnum
 
-from qtpy import QtCore, QtWidgets
-
 from cruiz.widgets.util import BlockSignals
+
+from qtpy import QtCore, QtWidgets
 
 
 class KeyValueTable(QtWidgets.QTableWidget):

--- a/src/cruiz/manage_local_cache/widgets/movelocalcachedialog.py
+++ b/src/cruiz/manage_local_cache/widgets/movelocalcachedialog.py
@@ -11,19 +11,16 @@ import platform
 import shutil
 import typing
 
-from qtpy import QtCore, QtGui, QtWidgets
-
 import cruiz.globals
-
+from cruiz.pyside6.local_cache_move import Ui_LocalCacheMove
 from cruiz.settings.managers.namedlocalcache import (
     NamedLocalCacheSettings,
     NamedLocalCacheSettingsReader,
     NamedLocalCacheSettingsWriter,
 )
-
-from cruiz.pyside6.local_cache_move import Ui_LocalCacheMove
-
 from cruiz.widgets.util import search_for_dir_options
+
+from qtpy import QtCore, QtGui, QtWidgets
 
 if typing.TYPE_CHECKING:
     from cruiz.commands.context import ConanContext

--- a/src/cruiz/manage_local_cache/widgets/newlocalcachewizard.py
+++ b/src/cruiz/manage_local_cache/widgets/newlocalcachewizard.py
@@ -7,21 +7,18 @@ Wizard for creating new Conan local caches
 import platform
 import typing
 
-from qtpy import QtGui, QtWidgets
-
 import cruiz.globals
-
+import cruiz.workers.api as workers_api
 from cruiz.commands.context import ConanContext
-from cruiz.interop.commandparameters import CommandParameters
 from cruiz.commands.logdetails import LogDetails
+from cruiz.constants import DEFAULT_CACHE_NAME
+from cruiz.interop.commandparameters import CommandParameters
+from cruiz.pyside6.local_cache_new_wizard import Ui_NewLocalCacheWizard
 from cruiz.settings.managers.localcachepreferences import LocalCacheSettingsReader
 from cruiz.settings.managers.namedlocalcache import NamedLocalCacheCreator
 from cruiz.widgets.util import search_for_dir_options
-from cruiz.constants import DEFAULT_CACHE_NAME
 
-import cruiz.workers.api as workers_api
-
-from cruiz.pyside6.local_cache_new_wizard import Ui_NewLocalCacheWizard
+from qtpy import QtGui, QtWidgets
 
 
 class NewLocalCacheWizard(QtWidgets.QWizard):

--- a/src/cruiz/manage_local_cache/widgets/newlocalcachewizardpages.py
+++ b/src/cruiz/manage_local_cache/widgets/newlocalcachewizardpages.py
@@ -7,9 +7,9 @@ Wizard pages for naming new Conan local caches
 import platform
 import typing
 
-from qtpy import QtWidgets
-
 from cruiz.settings.managers.namedlocalcache import AllNamedLocalCacheSettingsReader
+
+from qtpy import QtWidgets
 
 
 class NewLocalCacheNamePage(QtWidgets.QWizardPage):

--- a/src/cruiz/manage_local_cache/widgets/remotestable.py
+++ b/src/cruiz/manage_local_cache/widgets/remotestable.py
@@ -4,13 +4,13 @@
 Widget for the table of local cache remote
 """
 
-from enum import IntEnum
 import typing
-
-from qtpy import QtCore, QtGui, QtWidgets
+from enum import IntEnum
 
 from cruiz.interop.pod import ConanRemote
 from cruiz.widgets.util import BlockSignals
+
+from qtpy import QtCore, QtGui, QtWidgets
 
 
 class RemotesTable(QtWidgets.QTableWidget):

--- a/src/cruiz/manage_local_cache/widgets/removeenvironmentdialog.py
+++ b/src/cruiz/manage_local_cache/widgets/removeenvironmentdialog.py
@@ -4,9 +4,9 @@
 Dialog for removing an environment variable
 """
 
-from qtpy import QtCore, QtWidgets
-
 from cruiz.pyside6.local_cache_remove_environment import Ui_RemoveEnvironmentDialog
+
+from qtpy import QtCore, QtWidgets
 
 
 class RemoveEnvironmentDialog(QtWidgets.QDialog):

--- a/src/cruiz/manage_local_cache/widgets/runconancommanddialog.py
+++ b/src/cruiz/manage_local_cache/widgets/runconancommanddialog.py
@@ -6,17 +6,14 @@ Dialog for running a Conan command in a local cache.
 
 import typing
 
-from qtpy import QtCore, QtWidgets
-
 import cruiz.globals
-
+import cruiz.workers.api as workers_api
 from cruiz.commands.context import ConanContext
 from cruiz.commands.logdetails import LogDetails
 from cruiz.interop.commandparameters import CommandParameters
-
 from cruiz.pyside6.local_cache_run_command_dialog import Ui_RunConanCommandDialog
 
-import cruiz.workers.api as workers_api
+from qtpy import QtCore, QtWidgets
 
 
 class RunConanCommandDialog(QtWidgets.QDialog):

--- a/src/cruiz/recipe/dependencyview.py
+++ b/src/cruiz/recipe/dependencyview.py
@@ -8,10 +8,10 @@ from __future__ import annotations
 
 import typing
 
-# TODO: note, change, as QtSvgWidgets wasn't available here previously
-from qtpy import QtWidgets, QtSvg, QtSvgWidgets
-
 from cruiz.svggraph import DependenciesToDigraph, DigraphToSVG, SVGScene
+
+# TODO: note, change, as QtSvgWidgets wasn't available here previously
+from qtpy import QtSvg, QtSvgWidgets, QtWidgets
 
 if typing.TYPE_CHECKING:
     from cruiz.interop.dependencygraph import DependencyGraph

--- a/src/cruiz/recipe/expressioneditordialog.py
+++ b/src/cruiz/recipe/expressioneditordialog.py
@@ -4,11 +4,11 @@
 Local workflow folder expression editor dialog
 """
 
-from qtpy import QtWidgets
-
 from cruiz.pyside6.recipe_local_workflow_expression_editor import (
     Ui_ExpressionEditor,
 )
+
+from qtpy import QtWidgets
 
 
 class ExpressionEditorDialog(QtWidgets.QDialog):

--- a/src/cruiz/recipe/findtextdialog.py
+++ b/src/cruiz/recipe/findtextdialog.py
@@ -4,9 +4,9 @@
 Conan recipe find text dialog
 """
 
-from qtpy import QtCore, QtWidgets
-
 from cruiz.pyside6.find_text_dialog import Ui_FindTextDialog
+
+from qtpy import QtCore, QtWidgets
 
 
 class FindTextDialog(QtWidgets.QDialog):

--- a/src/cruiz/recipe/recipe.py
+++ b/src/cruiz/recipe/recipe.py
@@ -8,9 +8,9 @@ from __future__ import annotations
 
 import typing
 
-from qtpy import QtCore
-
 from cruiz.commands.context import ConanContext
+
+from qtpy import QtCore
 
 if typing.TYPE_CHECKING:
     import pathlib

--- a/src/cruiz/recipe/recipewidget.py
+++ b/src/cruiz/recipe/recipewidget.py
@@ -10,6 +10,29 @@ import pathlib
 import re
 import typing
 
+import cruiz.globals
+import cruiz.revealonfilesystem
+import cruiz.workers.api as workers_api
+from cruiz.commands.context import ConanContext
+from cruiz.commands.logdetails import LogDetails
+from cruiz.exceptions import RecipeInspectionError
+from cruiz.interop.commandparameters import CommandParameters
+from cruiz.interop.dependencygraph import dependencygraph_from_node_dependees
+from cruiz.manage_local_cache import ManageLocalCachesDialog
+from cruiz.model.graphaslistmodel import DependenciesListModel, DependenciesTreeModel
+from cruiz.pyside6.recipe_window import Ui_RecipeWindow
+from cruiz.revealonfilesystem import reveal_on_filesystem
+from cruiz.settings.managers.basesettings import WorkflowCwd
+from cruiz.settings.managers.fontpreferences import FontSettingsReader, FontUsage
+from cruiz.settings.managers.generalpreferences import GeneralSettingsReader
+from cruiz.settings.managers.namedlocalcache import NamedLocalCacheSettingsReader
+from cruiz.settings.managers.recipe import (
+    RecipeSettings,
+    RecipeSettingsReader,
+    RecipeSettingsWriter,
+)
+from cruiz.widgets.util import BlockSignals, clear_widgets_from_layout
+
 from qtpy import QtCore, QtGui, QtWidgets
 
 try:
@@ -17,34 +40,10 @@ try:
 except ImportError as exc:
     print(exc)
 
-from cruiz.pyside6.recipe_window import Ui_RecipeWindow
-
-from cruiz.commands.context import ConanContext
-from cruiz.interop.commandparameters import CommandParameters
-from cruiz.interop.dependencygraph import dependencygraph_from_node_dependees
-from cruiz.commands.logdetails import LogDetails
-from cruiz.settings.managers.generalpreferences import GeneralSettingsReader
-from cruiz.settings.managers.basesettings import WorkflowCwd
-from cruiz.settings.managers.recipe import (
-    RecipeSettings,
-    RecipeSettingsReader,
-    RecipeSettingsWriter,
-)
-from cruiz.settings.managers.namedlocalcache import NamedLocalCacheSettingsReader
-from cruiz.settings.managers.fontpreferences import FontSettingsReader, FontUsage
-from cruiz.widgets.util import BlockSignals, clear_widgets_from_layout
-from cruiz.revealonfilesystem import reveal_on_filesystem
-import cruiz.workers.api as workers_api
-from cruiz.model.graphaslistmodel import DependenciesListModel, DependenciesTreeModel
-from cruiz.manage_local_cache import ManageLocalCachesDialog
-import cruiz.revealonfilesystem
-import cruiz.globals
-from cruiz.exceptions import RecipeInspectionError
-
-from .recipe import Recipe
-from .findtextdialog import FindTextDialog
-from .expressioneditordialog import ExpressionEditorDialog
 from .dependencyview import InverseDependencyViewDialog
+from .expressioneditordialog import ExpressionEditorDialog
+from .findtextdialog import FindTextDialog
+from .recipe import Recipe
 
 
 logger = logging.getLogger(__name__)

--- a/src/cruiz/recipe/toolbars/behaviour.py
+++ b/src/cruiz/recipe/toolbars/behaviour.py
@@ -7,23 +7,19 @@ Recipe behaviour toolbar
 import os
 import pathlib
 
-from qtpy import QtCore, QtWidgets
-
 import cruiz.globals
-
-from cruiz.pyside6.recipe_profile_frame import Ui_profileFrame
 from cruiz.pyside6.recipe_cpucores_frame import Ui_cpuCoresFrame
-
-from cruiz.widgets.util import BlockSignals
-
+from cruiz.pyside6.recipe_profile_frame import Ui_profileFrame
+from cruiz.recipe.recipe import Recipe
+from cruiz.settings.managers.namedlocalcache import NamedLocalCacheSettingsReader
 from cruiz.settings.managers.recipe import (
     RecipeSettings,
     RecipeSettingsReader,
     RecipeSettingsWriter,
 )
-from cruiz.settings.managers.namedlocalcache import NamedLocalCacheSettingsReader
+from cruiz.widgets.util import BlockSignals
 
-from cruiz.recipe.recipe import Recipe
+from qtpy import QtCore, QtWidgets
 
 
 class _ProfileFrame(QtWidgets.QFrame):

--- a/src/cruiz/recipe/toolbars/buildfeatures.py
+++ b/src/cruiz/recipe/toolbars/buildfeatures.py
@@ -6,26 +6,23 @@ Build features toolbar
 
 import typing
 
-from qtpy import QtCore, QtGui, QtWidgets
-
 from cruiz.constants import CompilerCacheTypes
-
-from cruiz.settings.managers.recipe import (
-    RecipeSettingsReader,
-    RecipeSettings,
-    RecipeSettingsWriter,
-)
-from cruiz.settings.managers.compilercachepreferences import CompilerCacheSettingsReader
-
-from cruiz.widgets.util import BlockSignals
-
 from cruiz.pyside6.recipe_cmake_features_frame import Ui_cmakeFeaturesFrame
-from cruiz.pyside6.recipe_compilercache_features_frame import (
-    Ui_compilerCacheFrame,
-)
 from cruiz.pyside6.recipe_compiler_cache_configuration_dialog import (
     Ui_CompilerCacheConfigurationDialog,
 )
+from cruiz.pyside6.recipe_compilercache_features_frame import (
+    Ui_compilerCacheFrame,
+)
+from cruiz.settings.managers.compilercachepreferences import CompilerCacheSettingsReader
+from cruiz.settings.managers.recipe import (
+    RecipeSettings,
+    RecipeSettingsReader,
+    RecipeSettingsWriter,
+)
+from cruiz.widgets.util import BlockSignals
+
+from qtpy import QtCore, QtGui, QtWidgets
 
 
 class _CMakeFeaturesFrame(QtWidgets.QFrame):

--- a/src/cruiz/recipe/toolbars/command.py
+++ b/src/cruiz/recipe/toolbars/command.py
@@ -4,28 +4,22 @@
 Recipe command toolbar
 """
 
-from io import StringIO
 import os
 import typing
-
-from qtpy import QtCore, QtGui, QtWidgets
+from io import StringIO
 
 import cruiz.globals
-
-from cruiz.settings.managers.generalpreferences import GeneralSettingsReader
-
-from cruiz.settings.managers.recipe import RecipeSettings, RecipeSettingsReader
-from cruiz.settings.managers.shortcuts import ShortcutSettingsReader
-from cruiz.settings.managers.compilercachepreferences import CompilerCacheSettingsReader
-
 import cruiz.workers.api as workers_api
-
-from cruiz.interop.commandparameters import CommandParameters
-
 from cruiz.constants import BuildFeatureConstants, CompilerCacheTypes
 from cruiz.environ import EnvironSaver
-
 from cruiz.exceptions import RecipeInspectionError
+from cruiz.interop.commandparameters import CommandParameters
+from cruiz.settings.managers.compilercachepreferences import CompilerCacheSettingsReader
+from cruiz.settings.managers.generalpreferences import GeneralSettingsReader
+from cruiz.settings.managers.recipe import RecipeSettings, RecipeSettingsReader
+from cruiz.settings.managers.shortcuts import ShortcutSettingsReader
+
+from qtpy import QtCore, QtGui, QtWidgets
 
 
 IS_CONAN_V1 = cruiz.globals.CONAN_MAJOR_VERSION == 1

--- a/src/cruiz/remote_browser/pages/packagebinarypage.py
+++ b/src/cruiz/remote_browser/pages/packagebinarypage.py
@@ -13,15 +13,11 @@ import tarfile
 import tempfile
 import typing
 
-from qtpy import QtCore, QtGui, QtWidgets
-
-from qtpy import QtWebEngineCore
-
 import cruiz.globals
-
 from cruiz.interop.packagebinaryparameters import PackageBinaryParameters
-
 from cruiz.pyside6.remote_browser_fileview import Ui_remote_browser_fileview
+
+from qtpy import QtCore, QtGui, QtWebEngineCore, QtWidgets
 
 from .page import Page
 

--- a/src/cruiz/remote_browser/pages/packageidpage.py
+++ b/src/cruiz/remote_browser/pages/packageidpage.py
@@ -6,10 +6,10 @@ Remote browser page
 
 import typing
 
-from qtpy import QtCore, QtGui, QtWidgets
-
 from cruiz.interop.packageidparameters import PackageIdParameters
 from cruiz.widgets.util import BlockSignals
+
+from qtpy import QtCore, QtGui, QtWidgets
 
 from .page import Page
 

--- a/src/cruiz/remote_browser/pages/packagereferencepage.py
+++ b/src/cruiz/remote_browser/pages/packagereferencepage.py
@@ -6,17 +6,13 @@ Remote browser page
 
 import typing
 
-from qtpy import QtCore, QtGui, QtWidgets
-
 import cruiz.globals
-
 from cruiz.commands.conanconf import ConanConfigBoolean
-
 from cruiz.interop.searchrecipesparameters import SearchRecipesParameters
-
 from cruiz.settings.managers.namedlocalcache import AllNamedLocalCacheSettingsReader
-
 from cruiz.widgets.util import BlockSignals
+
+from qtpy import QtCore, QtGui, QtWidgets
 
 from .page import Page
 

--- a/src/cruiz/remote_browser/pages/packagerevisionpage.py
+++ b/src/cruiz/remote_browser/pages/packagerevisionpage.py
@@ -6,9 +6,9 @@ Remote browser page
 
 import typing
 
-from qtpy import QtCore, QtGui, QtWidgets
-
 from cruiz.interop.packagerevisionsparameters import PackageRevisionsParameters
+
+from qtpy import QtCore, QtGui, QtWidgets
 
 from .page import Page
 

--- a/src/cruiz/remote_browser/pages/reciperevisionpage.py
+++ b/src/cruiz/remote_browser/pages/reciperevisionpage.py
@@ -6,9 +6,9 @@ Remote browser page
 
 import typing
 
-from qtpy import QtCore, QtGui, QtWidgets
-
 from cruiz.interop.reciperevisionsparameters import RecipeRevisionsParameters
+
+from qtpy import QtCore, QtGui, QtWidgets
 
 from .page import Page
 

--- a/src/cruiz/remote_browser/remotebrowser.py
+++ b/src/cruiz/remote_browser/remotebrowser.py
@@ -7,13 +7,12 @@ Remote browser
 import logging
 import typing
 
-from qtpy import QtCore, QtGui, QtWidgets
-
-from cruiz.pyside6.remote_browser import Ui_remotebrowser
-
 from cruiz.commands.context import ConanContext
 from cruiz.commands.logdetails import LogDetails
 from cruiz.constants import DEFAULT_CACHE_NAME
+from cruiz.pyside6.remote_browser import Ui_remotebrowser
+
+from qtpy import QtCore, QtGui, QtWidgets
 
 logger = logging.getLogger(__name__)
 

--- a/src/cruiz/settings/ensuredefaultlocalcache.py
+++ b/src/cruiz/settings/ensuredefaultlocalcache.py
@@ -4,12 +4,11 @@
 Utility to ensure a default local cache exists
 """
 
+from cruiz.constants import DEFAULT_CACHE_NAME
 from cruiz.settings.managers.namedlocalcache import (
     AllNamedLocalCacheSettingsReader,
     NamedLocalCacheCreator,
 )
-
-from cruiz.constants import DEFAULT_CACHE_NAME
 
 
 def ensure_default_local_cache() -> None:

--- a/src/cruiz/settings/managers/basesettings.py
+++ b/src/cruiz/settings/managers/basesettings.py
@@ -6,10 +6,10 @@ Settings base classes
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from enum import IntEnum
 import inspect
 import typing
+from dataclasses import dataclass
+from enum import IntEnum
 
 from qtpy import QtCore, QtGui
 

--- a/src/cruiz/settings/managers/cmakepreferences.py
+++ b/src/cruiz/settings/managers/cmakepreferences.py
@@ -8,12 +8,12 @@ import typing
 
 from .basesettings import (
     BaseSettings,
-    StringSetting,
     ComparableCommonSettings,
     SettingMeta,
+    StringSetting,
 )
-from .writermixin import _WriterMixin
 from .valueclasses import ScalarValue
+from .writermixin import _WriterMixin
 
 
 class CMakeSettings(ComparableCommonSettings):

--- a/src/cruiz/settings/managers/compilercachepreferences.py
+++ b/src/cruiz/settings/managers/compilercachepreferences.py
@@ -8,12 +8,12 @@ import typing
 
 from .basesettings import (
     BaseSettings,
-    StringSetting,
     ComparableCommonSettings,
     SettingMeta,
+    StringSetting,
 )
-from .writermixin import _WriterMixin
 from .valueclasses import ScalarValue
+from .writermixin import _WriterMixin
 
 
 class CompilerCacheSettings(ComparableCommonSettings):

--- a/src/cruiz/settings/managers/conanpreferences.py
+++ b/src/cruiz/settings/managers/conanpreferences.py
@@ -8,12 +8,12 @@ import typing
 
 from .basesettings import (
     BaseSettings,
-    StringSetting,
     ComparableCommonSettings,
     SettingMeta,
+    StringSetting,
 )
-from .writermixin import _WriterMixin
 from .valueclasses import ScalarValue
+from .writermixin import _WriterMixin
 
 
 class ConanSettings(ComparableCommonSettings):

--- a/src/cruiz/settings/managers/fontpreferences.py
+++ b/src/cruiz/settings/managers/fontpreferences.py
@@ -4,18 +4,18 @@
 Settings context managers for font preferences
 """
 
-from enum import Enum
 import typing
+from enum import Enum
 
 from .basesettings import (
     BaseSettings,
-    StringSetting,
-    IntSetting,
     ComparableCommonSettings,
+    IntSetting,
     SettingMeta,
+    StringSetting,
 )
-from .writermixin import _WriterMixin
 from .valueclasses import ScalarValue
+from .writermixin import _WriterMixin
 
 
 class FontUsage(Enum):

--- a/src/cruiz/settings/managers/generalpreferences.py
+++ b/src/cruiz/settings/managers/generalpreferences.py
@@ -12,13 +12,13 @@ from qtpy import QtCore, QtGui
 from .basesettings import (
     BaseSettings,
     BoolSetting,
-    StringSetting,
     ColourSetting,
     ComparableCommonSettings,
     SettingMeta,
+    StringSetting,
 )
-from .writermixin import _WriterMixin
 from .valueclasses import ScalarValue
+from .writermixin import _WriterMixin
 
 
 class GeneralSettings(ComparableCommonSettings):

--- a/src/cruiz/settings/managers/graphvizpreferences.py
+++ b/src/cruiz/settings/managers/graphvizpreferences.py
@@ -8,12 +8,12 @@ import typing
 
 from .basesettings import (
     BaseSettings,
-    StringSetting,
     ComparableCommonSettings,
     SettingMeta,
+    StringSetting,
 )
-from .writermixin import _WriterMixin
 from .valueclasses import ScalarValue
+from .writermixin import _WriterMixin
 
 
 class GraphVizSettings(ComparableCommonSettings):

--- a/src/cruiz/settings/managers/localcachepreferences.py
+++ b/src/cruiz/settings/managers/localcachepreferences.py
@@ -8,12 +8,12 @@ import typing
 
 from .basesettings import (
     BaseSettings,
-    StringSetting,
     ComparableCommonSettings,
     SettingMeta,
+    StringSetting,
 )
-from .writermixin import _WriterMixin
 from .valueclasses import ScalarValue
+from .writermixin import _WriterMixin
 
 
 # TODO: rename to NewLocalCacheSettings?

--- a/src/cruiz/settings/managers/namedlocalcache.py
+++ b/src/cruiz/settings/managers/namedlocalcache.py
@@ -8,17 +8,16 @@ from __future__ import annotations
 
 import typing
 
-from .writermixin import _WriterMixin
-from .valueclasses import ScalarValue, DictValue, ListValue
-
 from .basesettings import (
     BaseSettings,
-    StringSetting,
-    DictSetting,
     CommonSettings,
-    SettingMeta,
+    DictSetting,
     ListSetting,
+    SettingMeta,
+    StringSetting,
 )
+from .valueclasses import DictValue, ListValue, ScalarValue
+from .writermixin import _WriterMixin
 
 if typing.TYPE_CHECKING:
     from cruiz.interop.pod import ExtraProfileDirectory

--- a/src/cruiz/settings/managers/ninjapreferences.py
+++ b/src/cruiz/settings/managers/ninjapreferences.py
@@ -8,12 +8,12 @@ import typing
 
 from .basesettings import (
     BaseSettings,
-    StringSetting,
     ComparableCommonSettings,
     SettingMeta,
+    StringSetting,
 )
-from .writermixin import _WriterMixin
 from .valueclasses import ScalarValue
+from .writermixin import _WriterMixin
 
 
 class NinjaSettings(ComparableCommonSettings):

--- a/src/cruiz/settings/managers/recentconanconfigs.py
+++ b/src/cruiz/settings/managers/recentconanconfigs.py
@@ -6,9 +6,9 @@ Settings context manager for recent Conan configurations
 
 import typing
 
-from .basesettings import BaseSettings, ListSetting, CommonSettings, SettingMeta
-from .writermixin import _WriterMixin
+from .basesettings import BaseSettings, CommonSettings, ListSetting, SettingMeta
 from .valueclasses import ListValue
+from .writermixin import _WriterMixin
 
 
 # TODO: CommonSettings isn't completely used

--- a/src/cruiz/settings/managers/recipe.py
+++ b/src/cruiz/settings/managers/recipe.py
@@ -6,26 +6,27 @@ Settings context manager for recipes
 
 from __future__ import annotations
 
-from multiprocessing import cpu_count
 import pathlib
 import typing
+from multiprocessing import cpu_count
+
+from cruiz.exceptions import InconsistentSettingsError
 
 from qtpy import QtCore
-from cruiz.exceptions import InconsistentSettingsError
 
 from .basesettings import (
     BaseSettings,
     BoolSetting,
-    StringSetting,
-    IntSetting,
+    ComparableCommonSettings,
     DictSetting,
+    IntSetting,
+    SettingMeta,
+    StringSetting,
     WorkflowCwd,
     WorkflowCwdSetting,
-    ComparableCommonSettings,
-    SettingMeta,
 )
+from .valueclasses import DictValue, ScalarValue
 from .writermixin import _WriterMixin
-from .valueclasses import ScalarValue, DictValue
 
 if typing.TYPE_CHECKING:
     from cruiz.constants import CompilerCacheTypes

--- a/src/cruiz/settings/managers/shortcuts.py
+++ b/src/cruiz/settings/managers/shortcuts.py
@@ -8,12 +8,12 @@ import typing
 
 from .basesettings import (
     BaseSettings,
-    StringSetting,
     ComparableCommonSettings,
     SettingMeta,
+    StringSetting,
 )
-from .writermixin import _WriterMixin
 from .valueclasses import ScalarValue
+from .writermixin import _WriterMixin
 
 
 class ShortcutSettings(ComparableCommonSettings):

--- a/src/cruiz/settings/managers/valueclasses.py
+++ b/src/cruiz/settings/managers/valueclasses.py
@@ -4,8 +4,8 @@
 Settings context manager value classes
 """
 
-from dataclasses import dataclass
 import typing
+from dataclasses import dataclass
 
 
 @dataclass

--- a/src/cruiz/settings/managers/writermixin.py
+++ b/src/cruiz/settings/managers/writermixin.py
@@ -4,9 +4,8 @@
 Mixin for helping to write settings
 """
 
-from enum import Enum
-
 import typing
+from enum import Enum
 
 from qtpy import QtGui
 

--- a/src/cruiz/settings/models/recipesmodel.py
+++ b/src/cruiz/settings/models/recipesmodel.py
@@ -6,11 +6,10 @@ Qt model for recipes
 
 import typing
 
-from qtpy import QtCore
-
-
-from cruiz.settings.managers.recipe import RecipeSettingsReader
 import cruiz.globals
+from cruiz.settings.managers.recipe import RecipeSettingsReader
+
+from qtpy import QtCore
 
 
 class RecipesModel(QtCore.QAbstractTableModel):

--- a/src/cruiz/settings/preferencesdialog.py
+++ b/src/cruiz/settings/preferencesdialog.py
@@ -8,29 +8,40 @@ import json
 import pathlib
 import typing
 
-from qtpy import QtCore, QtGui, QtWidgets
-
 import cruiz.globals
-
-from cruiz.settings.managers.namedlocalcache import NamedLocalCacheSettingsReader
-
+from cruiz.constants import DEFAULT_CACHE_NAME
 from cruiz.pyside6.preferences import Ui_PreferencesDialog
-
-from cruiz.settings.managers.generalpreferences import (
-    GeneralSettings,
-    GeneralSettingsReader,
-    GeneralSettingsWriter,
+from cruiz.settings.managers.cleansettings import sanitise_settings
+from cruiz.settings.managers.cmakepreferences import (
+    CMakeSettings,
+    CMakeSettingsReader,
+    CMakeSettingsWriter,
 )
-from cruiz.settings.managers.fontpreferences import (
-    FontUsage,
-    FontSettings,
-    FontSettingsReader,
-    FontSettingsWriter,
+from cruiz.settings.managers.compilercachepreferences import (
+    CompilerCacheSettings,
+    CompilerCacheSettingsReader,
+    CompilerCacheSettingsWriter,
 )
 from cruiz.settings.managers.conanpreferences import (
     ConanSettings,
     ConanSettingsReader,
     ConanSettingsWriter,
+)
+from cruiz.settings.managers.fontpreferences import (
+    FontSettings,
+    FontSettingsReader,
+    FontSettingsWriter,
+    FontUsage,
+)
+from cruiz.settings.managers.generalpreferences import (
+    GeneralSettings,
+    GeneralSettingsReader,
+    GeneralSettingsWriter,
+)
+from cruiz.settings.managers.graphvizpreferences import (
+    GraphVizSettings,
+    GraphVizSettingsReader,
+    GraphVizSettingsWriter,
 )
 from cruiz.settings.managers.localcachepreferences import (
     LocalCacheSettings,
@@ -40,60 +51,43 @@ from cruiz.settings.managers.localcachepreferences import (
 from cruiz.settings.managers.namedlocalcache import (
     AllNamedLocalCacheSettingsReader,
     NamedLocalCacheDeleter,
-)
-from cruiz.settings.managers.graphvizpreferences import (
-    GraphVizSettings,
-    GraphVizSettingsReader,
-    GraphVizSettingsWriter,
-)
-from cruiz.settings.managers.cmakepreferences import (
-    CMakeSettings,
-    CMakeSettingsReader,
-    CMakeSettingsWriter,
+    NamedLocalCacheSettingsReader,
 )
 from cruiz.settings.managers.ninjapreferences import (
     NinjaSettings,
     NinjaSettingsReader,
     NinjaSettingsWriter,
 )
-from cruiz.settings.managers.compilercachepreferences import (
-    CompilerCacheSettings,
-    CompilerCacheSettingsReader,
-    CompilerCacheSettingsWriter,
-)
-from cruiz.settings.managers.recentrecipes import (
-    RecentRecipeSettingsReader,
-    RecentRecipeSettingsDeleter,
-)
-from cruiz.settings.managers.recipe import (
-    RecipeSettingsReader,
-    RecipeSettingsWriter,
-    RecipeSettings,
-    RecipeSettingsDeleter,
-)
 from cruiz.settings.managers.recentconanconfigs import (
-    RecentConanConfigSettingsReader,
     RecentConanConfigSettingsDeleter,
+    RecentConanConfigSettingsReader,
 )
 from cruiz.settings.managers.recentconanremotes import (
-    RecentConanRemotesSettingsReader,
     RecentConanRemotesSettingsDeleter,
+    RecentConanRemotesSettingsReader,
 )
+from cruiz.settings.managers.recentrecipes import (
+    RecentRecipeSettingsDeleter,
+    RecentRecipeSettingsReader,
+)
+from cruiz.settings.managers.recipe import (
+    RecipeSettings,
+    RecipeSettingsDeleter,
+    RecipeSettingsReader,
+    RecipeSettingsWriter,
+)
+from cruiz.settings.managers.restoredefaults import factory_reset
 from cruiz.settings.managers.shortcuts import (
     ShortcutSettings,
     ShortcutSettingsReader,
     ShortcutSettingsWriter,
 )
-from cruiz.settings.managers.cleansettings import sanitise_settings
-from cruiz.settings.managers.restoredefaults import factory_reset
-
-from cruiz.settings.models.recentconanremotesmodel import RecentConanRemotesModel
 from cruiz.settings.models.recentconanconfigmodel import RecentConanConfigModel
+from cruiz.settings.models.recentconanremotesmodel import RecentConanRemotesModel
 from cruiz.settings.models.recipesmodel import RecipesModel
-
 from cruiz.widgets.util import BlockSignals, search_for_file_options
 
-from cruiz.constants import DEFAULT_CACHE_NAME
+from qtpy import QtCore, QtGui, QtWidgets
 
 
 class PreferencesDialog(QtWidgets.QDialog):

--- a/src/cruiz/svggraph.py
+++ b/src/cruiz/svggraph.py
@@ -9,11 +9,12 @@ from __future__ import annotations
 import os
 import typing
 
-import graphviz
-from qtpy import QtCore, QtGui, QtSvg, QtWidgets, QtSvgWidgets
-
-from cruiz.settings.managers.graphvizpreferences import GraphVizSettingsReader
 from cruiz.environ import EnvironSaver
+from cruiz.settings.managers.graphvizpreferences import GraphVizSettingsReader
+
+import graphviz
+
+from qtpy import QtCore, QtGui, QtSvg, QtSvgWidgets, QtWidgets
 
 if typing.TYPE_CHECKING:
     from cruiz.interop.packagenode import PackageNode

--- a/src/cruiz/widgets/__init__.py
+++ b/src/cruiz/widgets/__init__.py
@@ -4,6 +4,6 @@
 Helpful widget classes and utilities
 """
 
-from cruiz.widgets.shortcutlineedit import ShortcutLineEdit as ShortcutLineEdit
 from cruiz.widgets.aboutcruizdialog import AboutDialog as AboutDialog
 from cruiz.widgets.debugging import log_created_widget as log_created_widget
+from cruiz.widgets.shortcutlineedit import ShortcutLineEdit as ShortcutLineEdit

--- a/src/cruiz/widgets/aboutcruizdialog.py
+++ b/src/cruiz/widgets/aboutcruizdialog.py
@@ -7,11 +7,10 @@ Dialog to show cruiz information
 import sys
 import typing
 
-from qtpy import QtCore, QtGui, QtWidgets
-
+from cruiz.pyside6.about_dialog import Ui_AboutCruiz
 from cruiz.version import get_version
 
-from cruiz.pyside6.about_dialog import Ui_AboutCruiz
+from qtpy import QtCore, QtGui, QtWidgets
 
 
 class AboutDialog(QtWidgets.QDialog):

--- a/src/cruiz/workers/api/common/endmessagethread.py
+++ b/src/cruiz/workers/api/common/endmessagethread.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import typing
 
-from cruiz.interop.message import Message, End
+from cruiz.interop.message import End, Message
 
 if typing.TYPE_CHECKING:
     import multiprocessing

--- a/src/cruiz/workers/api/v1/arbitrary.py
+++ b/src/cruiz/workers/api/v1/arbitrary.py
@@ -7,6 +7,7 @@ Child process commands
 from __future__ import annotations
 
 import typing
+
 from cruiz.interop.message import Message, Success
 
 from . import worker

--- a/src/cruiz/workers/api/v1/build.py
+++ b/src/cruiz/workers/api/v1/build.py
@@ -7,6 +7,7 @@ Child process commands
 from __future__ import annotations
 
 import typing
+
 from cruiz.interop.message import Message, Success
 
 from . import worker

--- a/src/cruiz/workers/api/v1/cmakebuildtool.py
+++ b/src/cruiz/workers/api/v1/cmakebuildtool.py
@@ -9,9 +9,9 @@ from __future__ import annotations
 import multiprocessing
 import typing
 
-from cruiz.interop.message import Message, Success, Stdout, Stderr
-from cruiz.workers.utils.worker import Worker
 import cruiz.runcommands
+from cruiz.interop.message import Message, Stderr, Stdout, Success
+from cruiz.workers.utils.worker import Worker
 
 if typing.TYPE_CHECKING:
     from cruiz.interop.commandparameters import CommandParameters

--- a/src/cruiz/workers/api/v1/conanapi.py
+++ b/src/cruiz/workers/api/v1/conanapi.py
@@ -17,14 +17,14 @@ from .monkeypatch import _do_monkey_patching
 _do_monkey_patching()
 
 # pylint: disable=wrong-import-order,wrong-import-position
-from conans.client import conan_api, output, runner  # noqa: E402
+from conans.client import conan_api, output, runner  # noqa: E402, I100
 from conans.paths import get_conan_user_home  # noqa: E402
 
 import cruiz.workers.utils.qtlogger  # noqa: E402
-from cruiz.workers.utils.stream import QueuedStreamSix  # noqa: E402
 from cruiz.interop.commandparameters import CommandParameters  # noqa: E402
 from cruiz.interop.commonparameters import CommonParameters  # noqa: E402
-from cruiz.interop.message import Message, Stdout, Stderr  # noqa: E402
+from cruiz.interop.message import Message, Stderr, Stdout  # noqa: E402
+from cruiz.workers.utils.stream import QueuedStreamSix  # noqa: E402
 
 
 def instance(

--- a/src/cruiz/workers/api/v1/configinstall.py
+++ b/src/cruiz/workers/api/v1/configinstall.py
@@ -6,10 +6,10 @@ Child process commands
 
 from __future__ import annotations
 
-from io import StringIO
 import typing
+from io import StringIO
 
-from cruiz.interop.message import Message, Success, Stdout
+from cruiz.interop.message import Message, Stdout, Success
 
 from . import worker
 

--- a/src/cruiz/workers/api/v1/deletecmakecache.py
+++ b/src/cruiz/workers/api/v1/deletecmakecache.py
@@ -6,10 +6,10 @@ Child process commands
 
 from __future__ import annotations
 
-from pathlib import Path
 import typing
+from pathlib import Path
 
-from cruiz.interop.message import Message, Success, Stdout
+from cruiz.interop.message import Message, Stdout, Success
 from cruiz.workers.utils.worker import Worker
 
 if typing.TYPE_CHECKING:

--- a/src/cruiz/workers/api/v1/imports.py
+++ b/src/cruiz/workers/api/v1/imports.py
@@ -7,6 +7,7 @@ Child process commands
 from __future__ import annotations
 
 import typing
+
 from cruiz.interop.message import Message, Success
 
 from . import worker

--- a/src/cruiz/workers/api/v1/lockcreate.py
+++ b/src/cruiz/workers/api/v1/lockcreate.py
@@ -7,10 +7,10 @@ Child process commands
 from __future__ import annotations
 
 import typing
-from cruiz.interop.packagenode import PackageNode
+
 from cruiz.interop.dependencygraph import DependencyGraph
 from cruiz.interop.message import Message, Success
-
+from cruiz.interop.packagenode import PackageNode
 from cruiz.workers.utils.formatoptions import format_options
 
 from . import worker

--- a/src/cruiz/workers/api/v1/meta.py
+++ b/src/cruiz/workers/api/v1/meta.py
@@ -9,11 +9,11 @@ from __future__ import annotations
 import multiprocessing
 import os
 import pathlib
-import urllib.parse
 import typing
+import urllib.parse
 
-from cruiz.interop.pod import ConanRemote, ConanHook
-from cruiz.interop.message import Message, Success, Failure
+from cruiz.interop.message import Failure, Message, Success
+from cruiz.interop.pod import ConanHook, ConanRemote
 
 from . import worker
 

--- a/src/cruiz/workers/api/v1/package.py
+++ b/src/cruiz/workers/api/v1/package.py
@@ -7,6 +7,7 @@ Child process commands
 from __future__ import annotations
 
 import typing
+
 from cruiz.interop.message import Message, Success
 
 from . import worker

--- a/src/cruiz/workers/api/v1/packagebinary.py
+++ b/src/cruiz/workers/api/v1/packagebinary.py
@@ -7,6 +7,7 @@ Child process commands
 from __future__ import annotations
 
 import typing
+
 from cruiz.interop.message import Message, Success
 
 from . import worker

--- a/src/cruiz/workers/api/v1/packagerevisions.py
+++ b/src/cruiz/workers/api/v1/packagerevisions.py
@@ -7,6 +7,7 @@ Child process commands
 from __future__ import annotations
 
 import typing
+
 from cruiz.interop.message import Message, Success
 
 from . import worker

--- a/src/cruiz/workers/api/v1/reciperevisions.py
+++ b/src/cruiz/workers/api/v1/reciperevisions.py
@@ -7,6 +7,7 @@ Child process commands
 from __future__ import annotations
 
 import typing
+
 from cruiz.interop.message import Message, Success
 
 from . import worker

--- a/src/cruiz/workers/api/v1/removeallpackages.py
+++ b/src/cruiz/workers/api/v1/removeallpackages.py
@@ -7,7 +7,8 @@ Child process commands
 from __future__ import annotations
 
 import typing
-from cruiz.interop.message import Message, Success, Stdout
+
+from cruiz.interop.message import Message, Stdout, Success
 
 from . import worker
 

--- a/src/cruiz/workers/api/v1/removelocks.py
+++ b/src/cruiz/workers/api/v1/removelocks.py
@@ -7,6 +7,7 @@ Child process commands
 from __future__ import annotations
 
 import typing
+
 from cruiz.interop.message import Message, Success
 
 from . import worker

--- a/src/cruiz/workers/api/v1/removepackage.py
+++ b/src/cruiz/workers/api/v1/removepackage.py
@@ -7,7 +7,8 @@ Child process commands
 from __future__ import annotations
 
 import typing
-from cruiz.interop.message import Message, Success, Stdout
+
+from cruiz.interop.message import Message, Stdout, Success
 
 from . import worker
 

--- a/src/cruiz/workers/api/v2/arbitrary.py
+++ b/src/cruiz/workers/api/v2/arbitrary.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import multiprocessing
 import typing
 
-from cruiz.interop.message import Message, Success, Failure
+from cruiz.interop.message import Failure, Message, Success
 
 from . import worker
 

--- a/src/cruiz/workers/api/v2/configinstall.py
+++ b/src/cruiz/workers/api/v2/configinstall.py
@@ -6,10 +6,10 @@ Worker for installing Conan local cache configuration
 
 from __future__ import annotations
 
-from io import StringIO
 import typing
+from io import StringIO
 
-from cruiz.interop.message import Message, Success, Stdout
+from cruiz.interop.message import Message, Stdout, Success
 
 from . import worker
 

--- a/src/cruiz/workers/api/v2/lockcreate.py
+++ b/src/cruiz/workers/api/v2/lockcreate.py
@@ -9,10 +9,9 @@ from __future__ import annotations
 import multiprocessing
 import typing
 
-from cruiz.interop.packagenode import PackageNode
 from cruiz.interop.dependencygraph import DependencyGraph
 from cruiz.interop.message import Message, Success
-
+from cruiz.interop.packagenode import PackageNode
 from cruiz.workers.utils.formatoptions import format_options_v2
 
 from . import worker

--- a/src/cruiz/workers/api/v2/meta.py
+++ b/src/cruiz/workers/api/v2/meta.py
@@ -12,11 +12,11 @@ from __future__ import annotations
 import multiprocessing
 import os
 import pathlib
-import urllib.parse
 import typing
+import urllib.parse
 
-from cruiz.interop.message import Message, Failure, Success
-from cruiz.interop.pod import ConanRemote, ConanHook
+from cruiz.interop.message import Failure, Message, Success
+from cruiz.interop.pod import ConanHook, ConanRemote
 
 from . import worker
 

--- a/src/cruiz/workers/api/v2/reciperevisions.py
+++ b/src/cruiz/workers/api/v2/reciperevisions.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import datetime
 import multiprocessing
 import typing
+
 from cruiz.interop.message import Message, Success
 
 from . import worker

--- a/src/cruiz/workers/api/v2/removeallpackages.py
+++ b/src/cruiz/workers/api/v2/removeallpackages.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import typing
 
-from cruiz.interop.message import Message, Success, Stdout
+from cruiz.interop.message import Message, Stdout, Success
 
 from . import worker
 

--- a/src/cruiz/workers/api/v2/removepackage.py
+++ b/src/cruiz/workers/api/v2/removepackage.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import typing
 
-from cruiz.interop.message import Message, Success, Stdout
+from cruiz.interop.message import Message, Stdout, Success
 
 from . import worker
 

--- a/src/cruiz/workers/api/v2/worker.py
+++ b/src/cruiz/workers/api/v2/worker.py
@@ -9,11 +9,10 @@ from __future__ import annotations
 import multiprocessing
 import typing
 
-from cruiz.workers.utils.worker import Worker
-from cruiz.workers.utils.stream import QueuedStreamSix
-
-from cruiz.interop.message import Message, Stdout, Stderr
 import cruiz.runcommands
+from cruiz.interop.message import Message, Stderr, Stdout
+from cruiz.workers.utils.stream import QueuedStreamSix
+from cruiz.workers.utils.worker import Worker
 
 
 def _patch_conan_output_initialiser(queue: multiprocessing.Queue[Message]) -> None:

--- a/src/cruiz/workers/utils/colorarma_conversion.py
+++ b/src/cruiz/workers/utils/colorarma_conversion.py
@@ -5,8 +5,8 @@ Util module to convert colorama escpe codes to HTML
 """
 
 import copy
-from io import StringIO
 import re
+from io import StringIO
 
 import colorama
 

--- a/src/cruiz/workers/utils/qtlogger.py
+++ b/src/cruiz/workers/utils/qtlogger.py
@@ -12,7 +12,7 @@ import typing
 
 import conans.util.log
 
-from cruiz.interop.message import Message, ConanLogMessage
+from cruiz.interop.message import ConanLogMessage, Message
 
 
 class _Singleton(type):

--- a/src/cruiz/workers/utils/stream.py
+++ b/src/cruiz/workers/utils/stream.py
@@ -7,8 +7,9 @@ Stream data via a multiprocessing queue
 from __future__ import annotations
 
 import multiprocessing
-import six
 import typing
+
+import six
 
 from .colorarma_conversion import convert_from_colorama_to_html
 

--- a/src/cruiz/workers/utils/text2html.py
+++ b/src/cruiz/workers/utils/text2html.py
@@ -5,7 +5,6 @@ Converting text to HTML
 """
 
 import html as html_module
-
 from io import StringIO
 
 

--- a/src/cruiz/workers/utils/worker.py
+++ b/src/cruiz/workers/utils/worker.py
@@ -13,14 +13,13 @@ import os
 import traceback
 import typing
 
-from qtpy import QtCore
-
 from cruiz.interop.commandparameters import CommandParameters
 from cruiz.interop.commonparameters import CommonParameters
-from cruiz.interop.message import Message, Failure, Stdout
-
-from cruiz.workers.utils.env import set_env, clear_conan_env
+from cruiz.interop.message import Failure, Message, Stdout
+from cruiz.workers.utils.env import clear_conan_env, set_env
 from cruiz.workers.utils.text2html import text_to_html
+
+from qtpy import QtCore
 
 if typing.TYPE_CHECKING:
     from cruiz.interop.searchrecipesparameters import SearchRecipesParameters


### PR DESCRIPTION
This removes any ambiguity, and has combined a few import statements.

A flake8 plugin flake8-import-order does the checks.