### PR TITLE
Fixes #207 tox cleanup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,7 +134,6 @@ testpaths = [
 [tool.tox.env.lint]
 deps = [
     "-r{toxinidir}/requirements_dev.txt",
-    "-r{toxinidir}/requirements.txt",
 ]
 commands = [
     ["pip", "install", "-e", "."],
@@ -147,7 +146,6 @@ commands = [
 [tool.tox.env.test]
 deps = [
     "-r{toxinidir}/requirements_dev.txt",
-    "-r{toxinidir}/requirements.txt",
 ]
 commands = [
     ["pip", "install", "."],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,6 +148,6 @@ deps = [
     "-r{toxinidir}/requirements_dev.txt",
 ]
 commands = [
-    ["pip", "install", "."],
+    ["pip", "install", "-e", "."],
     ["pytest"],
 ]


### PR DESCRIPTION
* Don't doubly specify the runtime dependencies
* Tests can now work on an editable install of cruiz