### PR TITLE
Fixes #215 Drop qtpy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,10 +56,6 @@ readme = {file = "README.md", content-type = "text/markdown"}
 [tool.mypy]
 python_version = "3.10"
 
-# configure variables so that QtPy is used correctly during analysis
-always_true = "PYSIDE6"
-always_false = ["PYQT5", "PYSIDE2", "PYQT6"]
-
 # exclude generated files
 exclude = "/pyside6/"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 PySide6>=6.8,<6.9
-qtpy>=2.4.2,<2.5
 conan<3
 graphviz>=0.19.1,<1
 psutil>=5.9.0,<6

--- a/src/cruiz/application.py
+++ b/src/cruiz/application.py
@@ -6,10 +6,10 @@ from __future__ import annotations
 
 import typing
 
+from PySide6 import QtCore, QtGui, QtWidgets
+
 from cruiz.settings.ensuredefaultlocalcache import ensure_default_local_cache
 from cruiz.settings.managers.fontpreferences import FontSettingsReader, FontUsage
-
-from qtpy import QtCore, QtGui, QtWidgets
 
 
 class Application(QtWidgets.QApplication):

--- a/src/cruiz/commands/conaninvocation.py
+++ b/src/cruiz/commands/conaninvocation.py
@@ -17,11 +17,11 @@ import sys
 import threading
 import typing
 
+from PySide6 import QtCore, QtWidgets
+
 from cruiz.settings.managers.generalpreferences import GeneralSettingsReader
 
 import psutil
-
-from qtpy import QtCore, QtWidgets
 
 from .messagereplyprocessor import MessageReplyProcessor
 

--- a/src/cruiz/commands/context.py
+++ b/src/cruiz/commands/context.py
@@ -9,14 +9,14 @@ import pathlib
 import typing
 from contextlib import contextmanager
 
+from PySide6 import QtCore, QtWidgets
+
 import cruiz.workers.api as workers_api
 from cruiz.constants import DEFAULT_CACHE_NAME
 from cruiz.exceptions import RecipeInspectionError
 from cruiz.interop.commandparameters import CommandParameters
 from cruiz.recipe.logs.command import CommandListWidgetItem, RecipeCommandHistoryWidget
 from cruiz.settings.managers.namedlocalcache import NamedLocalCacheSettingsReader
-
-from qtpy import QtCore, QtWidgets
 
 from .conanenv import get_conan_env
 from .conaninvocation import ConanInvocation

--- a/src/cruiz/commands/guardedlisttoflush.py
+++ b/src/cruiz/commands/guardedlisttoflush.py
@@ -4,7 +4,7 @@
 
 import typing
 
-from qtpy import QtCore, QtWidgets
+from PySide6 import QtCore, QtWidgets
 
 
 class GuardedListToFlush(QtCore.QObject):

--- a/src/cruiz/commands/logdetails.py
+++ b/src/cruiz/commands/logdetails.py
@@ -4,7 +4,7 @@
 
 import typing
 
-from qtpy import QtCore, QtWidgets
+from PySide6 import QtCore, QtWidgets
 
 from .guardedlisttoflush import GuardedListToFlush
 

--- a/src/cruiz/commands/messagereplyprocessor.py
+++ b/src/cruiz/commands/messagereplyprocessor.py
@@ -13,6 +13,8 @@ import multiprocessing
 import sys
 import typing
 
+from PySide6 import QtCore
+
 import cruiz.workers.api as workers_api
 from cruiz.dumpobjecttypes import dump_object_types
 from cruiz.interop.message import (
@@ -24,8 +26,6 @@ from cruiz.interop.message import (
     Stdout,
     Success,
 )
-
-from qtpy import QtCore
 
 logger = logging.getLogger(__name__)
 

--- a/src/cruiz/commands/metarequestconaninvocation.py
+++ b/src/cruiz/commands/metarequestconaninvocation.py
@@ -15,6 +15,8 @@ import sys
 import typing
 import urllib.parse
 
+from PySide6 import QtCore
+
 import cruiz.workers.api as workers_api
 from cruiz.dumpobjecttypes import dump_object_types
 from cruiz.interop.commandparameters import CommandParameters
@@ -25,8 +27,6 @@ from cruiz.interop.message import (
     Stdout,
     Success,
 )
-
-from qtpy import QtCore
 
 from .conanenv import get_conan_env
 

--- a/src/cruiz/entrypoint.py
+++ b/src/cruiz/entrypoint.py
@@ -9,7 +9,7 @@ import pathlib
 import platform
 import sys
 
-from qtpy import QtCore, QtWidgets
+from PySide6 import QtCore, QtWidgets
 
 
 CONAN_SPEC = importlib.util.find_spec("conans")

--- a/src/cruiz/load_recipe/loadrecipewizard.py
+++ b/src/cruiz/load_recipe/loadrecipewizard.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 import pathlib
 import typing
 
+from PySide6 import QtCore, QtWidgets
+
 import cruiz.globals
 from cruiz.commands.context import managed_conan_context
 from cruiz.commands.logdetails import LogDetails
@@ -14,8 +16,6 @@ from cruiz.constants import DEFAULT_CACHE_NAME
 from cruiz.exceptions import RecipeAlreadyOpenError, RecipeDoesNotExistError
 from cruiz.pyside6.load_recipe_wizard import Ui_LoadRecipeWizard
 from cruiz.settings.managers.recipe import RecipeSettings, RecipeSettingsReader
-
-from qtpy import QtCore, QtWidgets
 
 if typing.TYPE_CHECKING:
     from cruiz.recipe.recipe import Recipe

--- a/src/cruiz/load_recipe/pages/initialprofilepage.py
+++ b/src/cruiz/load_recipe/pages/initialprofilepage.py
@@ -6,12 +6,12 @@ from __future__ import annotations
 
 import typing
 
+from PySide6 import QtWidgets
+
 from cruiz.commands.context import managed_conan_context
 from cruiz.commands.logdetails import LogDetails
 from cruiz.settings.managers.recipe import RecipeSettingsReader
 from cruiz.widgets.util import BlockSignals
-
-from qtpy import QtWidgets
 
 if typing.TYPE_CHECKING:
     import pathlib

--- a/src/cruiz/load_recipe/pages/intropage.py
+++ b/src/cruiz/load_recipe/pages/intropage.py
@@ -2,7 +2,7 @@
 
 """Wizard introduction page."""
 
-from qtpy import QtWidgets
+from PySide6 import QtWidgets
 
 
 class LoadRecipeIntroPage(QtWidgets.QWizardPage):

--- a/src/cruiz/load_recipe/pages/localcachepage.py
+++ b/src/cruiz/load_recipe/pages/localcachepage.py
@@ -4,12 +4,12 @@
 
 import typing
 
+from PySide6 import QtWidgets
+
 from cruiz.manage_local_cache import ManageLocalCachesDialog
 from cruiz.settings.managers.namedlocalcache import AllNamedLocalCacheSettingsReader
 from cruiz.settings.managers.recipe import RecipeSettingsReader
 from cruiz.widgets.util import BlockSignals
-
-from qtpy import QtWidgets
 
 
 class LoadRecipeLocalCachePage(QtWidgets.QWizardPage):

--- a/src/cruiz/load_recipe/pages/packageversionpage.py
+++ b/src/cruiz/load_recipe/pages/packageversionpage.py
@@ -4,12 +4,12 @@
 
 import typing
 
+from PySide6 import QtCore, QtGui, QtWidgets
+
 import cruiz.globals
 from cruiz.settings.managers.conanpreferences import ConanSettingsReader
 from cruiz.settings.managers.recipe import RecipeSettingsReader
 from cruiz.widgets.util import BlockSignals
-
-from qtpy import QtCore, QtGui, QtWidgets
 
 
 class LoadRecipePackageVersionPage(QtWidgets.QWizardPage):

--- a/src/cruiz/mainwindow.py
+++ b/src/cruiz/mainwindow.py
@@ -14,6 +14,8 @@ import time
 import typing
 from functools import partial
 
+from PySide6 import QtCore, QtGui, QtWidgets
+
 import cruiz.config
 import cruiz.globals
 import cruiz.runcommands
@@ -49,9 +51,9 @@ from cruiz.widgets import (
     log_created_widget,
 )
 
+
 import psutil
 
-from qtpy import QtCore, QtGui, QtWidgets
 
 logger = logging.getLogger(__name__)
 

--- a/src/cruiz/manage_local_cache/managelocalcachesdialog.py
+++ b/src/cruiz/manage_local_cache/managelocalcachesdialog.py
@@ -11,6 +11,8 @@ import stat
 import typing
 from enum import IntEnum
 
+from PySide6 import QtCore, QtGui, QtWidgets
+
 import cruiz.globals
 from cruiz.commands.conanconf import ConanConfigBoolean
 from cruiz.commands.context import ConanContext
@@ -32,8 +34,6 @@ from cruiz.settings.managers.recentconanremotes import (
     RecentConanRemotesSettingsWriter,
 )
 from cruiz.widgets.util import BlockSignals
-
-from qtpy import QtCore, QtGui, QtWidgets
 
 from .widgets import (
     AddEnvironmentDialog,

--- a/src/cruiz/manage_local_cache/widgets/addenvironmentdialog.py
+++ b/src/cruiz/manage_local_cache/widgets/addenvironmentdialog.py
@@ -7,10 +7,10 @@ from __future__ import annotations
 import typing
 from dataclasses import dataclass
 
+from PySide6 import QtCore, QtGui, QtWidgets
+
 import cruiz.globals
 from cruiz.pyside6.local_cache_add_environment import Ui_AddEnvironmentDialog
-
-from qtpy import QtCore, QtGui, QtWidgets
 
 if typing.TYPE_CHECKING:
     from cruiz.commands.context import ConanContext

--- a/src/cruiz/manage_local_cache/widgets/addextraprofiledirectorydialog.py
+++ b/src/cruiz/manage_local_cache/widgets/addextraprofiledirectorydialog.py
@@ -4,13 +4,13 @@
 
 import typing
 
+from PySide6 import QtCore, QtGui, QtWidgets
+
 from cruiz.interop.pod import ExtraProfileDirectory
 from cruiz.pyside6.local_cache_add_profile_directory import (
     Ui_AddExtraProfileDirectoryDialog,
 )
 from cruiz.widgets.util import search_for_dir_options
-
-from qtpy import QtCore, QtGui, QtWidgets
 
 
 class AddExtraProfileDirectoryDialog(QtWidgets.QDialog):

--- a/src/cruiz/manage_local_cache/widgets/addremotedialog.py
+++ b/src/cruiz/manage_local_cache/widgets/addremotedialog.py
@@ -5,11 +5,11 @@
 import typing
 from functools import partial
 
+from PySide6 import QtCore, QtGui, QtWidgets
+
 from cruiz.interop.pod import ConanRemote
 from cruiz.pyside6.local_cache_add_remote import Ui_AddRemoteDialog
 from cruiz.settings.managers.recentconanremotes import RecentConanRemotesSettingsReader
-
-from qtpy import QtCore, QtGui, QtWidgets
 
 import validators
 

--- a/src/cruiz/manage_local_cache/widgets/configpathorurl.py
+++ b/src/cruiz/manage_local_cache/widgets/configpathorurl.py
@@ -4,7 +4,7 @@
 
 import typing
 
-from qtpy import QtGui, QtWidgets
+from PySide6 import QtGui, QtWidgets
 
 
 class LineEditWithCustomContextMenu(QtWidgets.QLineEdit):

--- a/src/cruiz/manage_local_cache/widgets/installconfigdialog.py
+++ b/src/cruiz/manage_local_cache/widgets/installconfigdialog.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 import typing
 from functools import partial
 
+from PySide6 import QtCore, QtGui, QtWidgets
+
 import cruiz.workers.api as workers_api
 from cruiz.interop.commandparameters import CommandParameters
 from cruiz.pyside6.local_cache_install_config import Ui_InstallConfigDialog
@@ -15,8 +17,6 @@ from cruiz.settings.managers.recentconanconfigs import (
     RecentConanConfigSettingsReader,
     RecentConanConfigSettingsWriter,
 )
-
-from qtpy import QtCore, QtGui, QtWidgets
 
 if typing.TYPE_CHECKING:
     from cruiz.commands.context import ConanContext

--- a/src/cruiz/manage_local_cache/widgets/keyvaluetable.py
+++ b/src/cruiz/manage_local_cache/widgets/keyvaluetable.py
@@ -4,9 +4,9 @@
 
 from enum import IntEnum
 
-from cruiz.widgets.util import BlockSignals
+from PySide6 import QtCore, QtWidgets
 
-from qtpy import QtCore, QtWidgets
+from cruiz.widgets.util import BlockSignals
 
 
 class KeyValueTable(QtWidgets.QTableWidget):

--- a/src/cruiz/manage_local_cache/widgets/movelocalcachedialog.py
+++ b/src/cruiz/manage_local_cache/widgets/movelocalcachedialog.py
@@ -9,6 +9,8 @@ import platform
 import shutil
 import typing
 
+from PySide6 import QtCore, QtGui, QtWidgets
+
 import cruiz.globals
 from cruiz.pyside6.local_cache_move import Ui_LocalCacheMove
 from cruiz.settings.managers.namedlocalcache import (
@@ -17,8 +19,6 @@ from cruiz.settings.managers.namedlocalcache import (
     NamedLocalCacheSettingsWriter,
 )
 from cruiz.widgets.util import search_for_dir_options
-
-from qtpy import QtCore, QtGui, QtWidgets
 
 if typing.TYPE_CHECKING:
     from cruiz.commands.context import ConanContext

--- a/src/cruiz/manage_local_cache/widgets/newlocalcachewizard.py
+++ b/src/cruiz/manage_local_cache/widgets/newlocalcachewizard.py
@@ -5,6 +5,8 @@
 import platform
 import typing
 
+from PySide6 import QtGui, QtWidgets
+
 import cruiz.globals
 import cruiz.workers.api as workers_api
 from cruiz.commands.context import ConanContext
@@ -15,8 +17,6 @@ from cruiz.pyside6.local_cache_new_wizard import Ui_NewLocalCacheWizard
 from cruiz.settings.managers.localcachepreferences import LocalCacheSettingsReader
 from cruiz.settings.managers.namedlocalcache import NamedLocalCacheCreator
 from cruiz.widgets.util import search_for_dir_options
-
-from qtpy import QtGui, QtWidgets
 
 
 class NewLocalCacheWizard(QtWidgets.QWizard):

--- a/src/cruiz/manage_local_cache/widgets/newlocalcachewizardpages.py
+++ b/src/cruiz/manage_local_cache/widgets/newlocalcachewizardpages.py
@@ -5,9 +5,9 @@
 import platform
 import typing
 
-from cruiz.settings.managers.namedlocalcache import AllNamedLocalCacheSettingsReader
+from PySide6 import QtWidgets
 
-from qtpy import QtWidgets
+from cruiz.settings.managers.namedlocalcache import AllNamedLocalCacheSettingsReader
 
 
 class NewLocalCacheNamePage(QtWidgets.QWizardPage):

--- a/src/cruiz/manage_local_cache/widgets/progressdialogs.py
+++ b/src/cruiz/manage_local_cache/widgets/progressdialogs.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import typing
 
-from qtpy import QtCore, QtWidgets
+from PySide6 import QtCore, QtWidgets
 
 if typing.TYPE_CHECKING:
     from cruiz.commands.context import ConanContext

--- a/src/cruiz/manage_local_cache/widgets/remotestable.py
+++ b/src/cruiz/manage_local_cache/widgets/remotestable.py
@@ -5,10 +5,10 @@
 import typing
 from enum import IntEnum
 
+from PySide6 import QtCore, QtGui, QtWidgets
+
 from cruiz.interop.pod import ConanRemote
 from cruiz.widgets.util import BlockSignals
-
-from qtpy import QtCore, QtGui, QtWidgets
 
 
 class RemotesTable(QtWidgets.QTableWidget):

--- a/src/cruiz/manage_local_cache/widgets/removeenvironmentdialog.py
+++ b/src/cruiz/manage_local_cache/widgets/removeenvironmentdialog.py
@@ -2,9 +2,9 @@
 
 """Dialog for removing an environment variable."""
 
-from cruiz.pyside6.local_cache_remove_environment import Ui_RemoveEnvironmentDialog
+from PySide6 import QtCore, QtWidgets
 
-from qtpy import QtCore, QtWidgets
+from cruiz.pyside6.local_cache_remove_environment import Ui_RemoveEnvironmentDialog
 
 
 class RemoveEnvironmentDialog(QtWidgets.QDialog):

--- a/src/cruiz/manage_local_cache/widgets/runconancommanddialog.py
+++ b/src/cruiz/manage_local_cache/widgets/runconancommanddialog.py
@@ -4,14 +4,14 @@
 
 import typing
 
+from PySide6 import QtCore, QtWidgets
+
 import cruiz.globals
 import cruiz.workers.api as workers_api
 from cruiz.commands.context import ConanContext
 from cruiz.commands.logdetails import LogDetails
 from cruiz.interop.commandparameters import CommandParameters
 from cruiz.pyside6.local_cache_run_command_dialog import Ui_RunConanCommandDialog
-
-from qtpy import QtCore, QtWidgets
 
 
 class RunConanCommandDialog(QtWidgets.QDialog):

--- a/src/cruiz/model/graphaslistmodel.py
+++ b/src/cruiz/model/graphaslistmodel.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import typing
 
-from qtpy import QtCore, QtGui
+from PySide6 import QtCore, QtGui
 
 if typing.TYPE_CHECKING:
     from cruiz.interop.dependencygraph import DependencyGraph

--- a/src/cruiz/recipe/dependencyview.py
+++ b/src/cruiz/recipe/dependencyview.py
@@ -6,10 +6,9 @@ from __future__ import annotations
 
 import typing
 
-from cruiz.svggraph import DependenciesToDigraph, DigraphToSVG, SVGScene
+from PySide6 import QtSvg, QtSvgWidgets, QtWidgets
 
-# TODO: note, change, as QtSvgWidgets wasn't available here previously
-from qtpy import QtSvg, QtSvgWidgets, QtWidgets
+from cruiz.svggraph import DependenciesToDigraph, DigraphToSVG, SVGScene
 
 if typing.TYPE_CHECKING:
     from cruiz.interop.dependencygraph import DependencyGraph

--- a/src/cruiz/recipe/expressioneditordialog.py
+++ b/src/cruiz/recipe/expressioneditordialog.py
@@ -2,11 +2,11 @@
 
 """Local workflow folder expression editor dialog."""
 
+from PySide6 import QtWidgets
+
 from cruiz.pyside6.recipe_local_workflow_expression_editor import (
     Ui_ExpressionEditor,
 )
-
-from qtpy import QtWidgets
 
 
 class ExpressionEditorDialog(QtWidgets.QDialog):

--- a/src/cruiz/recipe/findtextdialog.py
+++ b/src/cruiz/recipe/findtextdialog.py
@@ -2,9 +2,9 @@
 
 """Conan recipe find text dialog."""
 
-from cruiz.pyside6.find_text_dialog import Ui_FindTextDialog
+from PySide6 import QtCore, QtWidgets
 
-from qtpy import QtCore, QtWidgets
+from cruiz.pyside6.find_text_dialog import Ui_FindTextDialog
 
 
 class FindTextDialog(QtWidgets.QDialog):

--- a/src/cruiz/recipe/logs/command.py
+++ b/src/cruiz/recipe/logs/command.py
@@ -8,7 +8,7 @@ import pathlib
 import stat
 import typing
 
-from qtpy import QtCore, QtGui, QtWidgets
+from PySide6 import QtCore, QtGui, QtWidgets
 
 if typing.TYPE_CHECKING:
     from cruiz.interop.commandparameters import CommandParameters

--- a/src/cruiz/recipe/recipe.py
+++ b/src/cruiz/recipe/recipe.py
@@ -6,9 +6,9 @@ from __future__ import annotations
 
 import typing
 
-from cruiz.commands.context import ConanContext
+from PySide6 import QtCore
 
-from qtpy import QtCore
+from cruiz.commands.context import ConanContext
 
 if typing.TYPE_CHECKING:
     import pathlib

--- a/src/cruiz/recipe/recipewidget.py
+++ b/src/cruiz/recipe/recipewidget.py
@@ -8,6 +8,8 @@ import pathlib
 import re
 import typing
 
+from PySide6 import QtCore, QtGui, QtWidgets
+
 import cruiz.globals
 import cruiz.revealonfilesystem
 import cruiz.workers.api as workers_api
@@ -30,8 +32,6 @@ from cruiz.settings.managers.recipe import (
     RecipeSettingsWriter,
 )
 from cruiz.widgets.util import BlockSignals, clear_widgets_from_layout
-
-from qtpy import QtCore, QtGui, QtWidgets
 
 try:
     import git

--- a/src/cruiz/recipe/toolbars/behaviour.py
+++ b/src/cruiz/recipe/toolbars/behaviour.py
@@ -5,6 +5,8 @@
 import os
 import pathlib
 
+from PySide6 import QtCore, QtWidgets
+
 import cruiz.globals
 from cruiz.pyside6.recipe_cpucores_frame import Ui_cpuCoresFrame
 from cruiz.pyside6.recipe_profile_frame import Ui_profileFrame
@@ -16,8 +18,6 @@ from cruiz.settings.managers.recipe import (
     RecipeSettingsWriter,
 )
 from cruiz.widgets.util import BlockSignals
-
-from qtpy import QtCore, QtWidgets
 
 
 class _ProfileFrame(QtWidgets.QFrame):

--- a/src/cruiz/recipe/toolbars/buildfeatures.py
+++ b/src/cruiz/recipe/toolbars/buildfeatures.py
@@ -4,6 +4,8 @@
 
 import typing
 
+from PySide6 import QtCore, QtGui, QtWidgets
+
 from cruiz.constants import CompilerCacheTypes
 from cruiz.pyside6.recipe_cmake_features_frame import Ui_cmakeFeaturesFrame
 from cruiz.pyside6.recipe_compiler_cache_configuration_dialog import (
@@ -19,8 +21,6 @@ from cruiz.settings.managers.recipe import (
     RecipeSettingsWriter,
 )
 from cruiz.widgets.util import BlockSignals
-
-from qtpy import QtCore, QtGui, QtWidgets
 
 
 class _CMakeFeaturesFrame(QtWidgets.QFrame):

--- a/src/cruiz/recipe/toolbars/command.py
+++ b/src/cruiz/recipe/toolbars/command.py
@@ -6,6 +6,8 @@ import os
 import typing
 from io import StringIO
 
+from PySide6 import QtCore, QtGui, QtWidgets
+
 import cruiz.globals
 import cruiz.workers.api as workers_api
 from cruiz.constants import BuildFeatureConstants, CompilerCacheTypes
@@ -16,8 +18,6 @@ from cruiz.settings.managers.compilercachepreferences import CompilerCacheSettin
 from cruiz.settings.managers.generalpreferences import GeneralSettingsReader
 from cruiz.settings.managers.recipe import RecipeSettings, RecipeSettingsReader
 from cruiz.settings.managers.shortcuts import ShortcutSettingsReader
-
-from qtpy import QtCore, QtGui, QtWidgets
 
 
 IS_CONAN_V1 = cruiz.globals.CONAN_MAJOR_VERSION == 1

--- a/src/cruiz/remote_browser/pages/packagebinarypage.py
+++ b/src/cruiz/remote_browser/pages/packagebinarypage.py
@@ -11,11 +11,11 @@ import tarfile
 import tempfile
 import typing
 
+from PySide6 import QtCore, QtGui, QtWebEngineCore, QtWidgets
+
 import cruiz.globals
 from cruiz.interop.packagebinaryparameters import PackageBinaryParameters
 from cruiz.pyside6.remote_browser_fileview import Ui_remote_browser_fileview
-
-from qtpy import QtCore, QtGui, QtWebEngineCore, QtWidgets
 
 from .page import Page
 

--- a/src/cruiz/remote_browser/pages/packageidpage.py
+++ b/src/cruiz/remote_browser/pages/packageidpage.py
@@ -4,10 +4,10 @@
 
 import typing
 
+from PySide6 import QtCore, QtGui, QtWidgets
+
 from cruiz.interop.packageidparameters import PackageIdParameters
 from cruiz.widgets.util import BlockSignals
-
-from qtpy import QtCore, QtGui, QtWidgets
 
 from .page import Page
 

--- a/src/cruiz/remote_browser/pages/packagereferencepage.py
+++ b/src/cruiz/remote_browser/pages/packagereferencepage.py
@@ -4,13 +4,13 @@
 
 import typing
 
+from PySide6 import QtCore, QtGui, QtWidgets
+
 import cruiz.globals
 from cruiz.commands.conanconf import ConanConfigBoolean
 from cruiz.interop.searchrecipesparameters import SearchRecipesParameters
 from cruiz.settings.managers.namedlocalcache import AllNamedLocalCacheSettingsReader
 from cruiz.widgets.util import BlockSignals
-
-from qtpy import QtCore, QtGui, QtWidgets
 
 from .page import Page
 

--- a/src/cruiz/remote_browser/pages/packagerevisionpage.py
+++ b/src/cruiz/remote_browser/pages/packagerevisionpage.py
@@ -4,9 +4,9 @@
 
 import typing
 
-from cruiz.interop.packagerevisionsparameters import PackageRevisionsParameters
+from PySide6 import QtCore, QtGui, QtWidgets
 
-from qtpy import QtCore, QtGui, QtWidgets
+from cruiz.interop.packagerevisionsparameters import PackageRevisionsParameters
 
 from .page import Page
 

--- a/src/cruiz/remote_browser/pages/page.py
+++ b/src/cruiz/remote_browser/pages/page.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import typing
 
-from qtpy import QtCore, QtGui, QtWidgets
+from PySide6 import QtCore, QtGui, QtWidgets
 
 if typing.TYPE_CHECKING:
     from cruiz.commands.context import ConanContext

--- a/src/cruiz/remote_browser/pages/reciperevisionpage.py
+++ b/src/cruiz/remote_browser/pages/reciperevisionpage.py
@@ -4,9 +4,9 @@
 
 import typing
 
-from cruiz.interop.reciperevisionsparameters import RecipeRevisionsParameters
+from PySide6 import QtCore, QtGui, QtWidgets
 
-from qtpy import QtCore, QtGui, QtWidgets
+from cruiz.interop.reciperevisionsparameters import RecipeRevisionsParameters
 
 from .page import Page
 

--- a/src/cruiz/remote_browser/remotebrowser.py
+++ b/src/cruiz/remote_browser/remotebrowser.py
@@ -5,12 +5,12 @@
 import logging
 import typing
 
+from PySide6 import QtCore, QtGui, QtWidgets
+
 from cruiz.commands.context import ConanContext
 from cruiz.commands.logdetails import LogDetails
 from cruiz.constants import DEFAULT_CACHE_NAME
 from cruiz.pyside6.remote_browser import Ui_remotebrowser
-
-from qtpy import QtCore, QtGui, QtWidgets
 
 logger = logging.getLogger(__name__)
 

--- a/src/cruiz/restart.py
+++ b/src/cruiz/restart.py
@@ -2,7 +2,7 @@
 
 """Restart the whole application."""
 
-from qtpy import QtCore
+from PySide6 import QtCore
 
 
 def restart_cruiz() -> None:

--- a/src/cruiz/revealonfilesystem.py
+++ b/src/cruiz/revealonfilesystem.py
@@ -12,7 +12,7 @@ import os
 import pathlib
 import platform
 
-from qtpy import QtCore, QtWidgets
+from PySide6 import QtCore, QtWidgets
 
 
 def _run_apple_script(command: str) -> None:

--- a/src/cruiz/settings/managers/basesettings.py
+++ b/src/cruiz/settings/managers/basesettings.py
@@ -9,7 +9,7 @@ import typing
 from dataclasses import dataclass
 from enum import IntEnum
 
-from qtpy import QtCore, QtGui
+from PySide6 import QtCore, QtGui
 
 
 @dataclass

--- a/src/cruiz/settings/managers/cleansettings.py
+++ b/src/cruiz/settings/managers/cleansettings.py
@@ -4,7 +4,7 @@
 
 import pathlib
 
-from qtpy import QtCore, QtWidgets
+from PySide6 import QtCore, QtWidgets
 
 from .basesettings import BaseSettings
 from .recentrecipes import RecentRecipeSettingsDeleter, RecentRecipeSettingsWriter

--- a/src/cruiz/settings/managers/generalpreferences.py
+++ b/src/cruiz/settings/managers/generalpreferences.py
@@ -5,7 +5,7 @@
 import platform
 import typing
 
-from qtpy import QtCore, QtGui
+from PySide6 import QtCore, QtGui
 
 from .basesettings import (
     BaseSettings,

--- a/src/cruiz/settings/managers/recentrecipes.py
+++ b/src/cruiz/settings/managers/recentrecipes.py
@@ -4,7 +4,7 @@
 
 import typing
 
-from qtpy import QtCore
+from PySide6 import QtCore
 
 from .basesettings import BaseSettings, CommonSettings
 

--- a/src/cruiz/settings/managers/recipe.py
+++ b/src/cruiz/settings/managers/recipe.py
@@ -8,9 +8,9 @@ import pathlib
 import typing
 from multiprocessing import cpu_count
 
-from cruiz.exceptions import InconsistentSettingsError
+from PySide6 import QtCore
 
-from qtpy import QtCore
+from cruiz.exceptions import InconsistentSettingsError
 
 from .basesettings import (
     BaseSettings,

--- a/src/cruiz/settings/managers/writermixin.py
+++ b/src/cruiz/settings/managers/writermixin.py
@@ -5,7 +5,7 @@
 import typing
 from enum import Enum
 
-from qtpy import QtGui
+from PySide6 import QtGui
 
 from .basesettings import BaseSettings
 

--- a/src/cruiz/settings/models/recentconanconfigmodel.py
+++ b/src/cruiz/settings/models/recentconanconfigmodel.py
@@ -4,7 +4,7 @@
 
 import typing
 
-from qtpy import QtCore
+from PySide6 import QtCore
 
 
 class RecentConanConfigModel(QtCore.QAbstractListModel):

--- a/src/cruiz/settings/models/recentconanremotesmodel.py
+++ b/src/cruiz/settings/models/recentconanremotesmodel.py
@@ -4,7 +4,7 @@
 
 import typing
 
-from qtpy import QtCore
+from PySide6 import QtCore
 
 
 class RecentConanRemotesModel(QtCore.QAbstractListModel):

--- a/src/cruiz/settings/models/recipesmodel.py
+++ b/src/cruiz/settings/models/recipesmodel.py
@@ -4,10 +4,10 @@
 
 import typing
 
+from PySide6 import QtCore
+
 import cruiz.globals
 from cruiz.settings.managers.recipe import RecipeSettingsReader
-
-from qtpy import QtCore
 
 
 class RecipesModel(QtCore.QAbstractTableModel):

--- a/src/cruiz/settings/preferencesdialog.py
+++ b/src/cruiz/settings/preferencesdialog.py
@@ -6,6 +6,8 @@ import json
 import pathlib
 import typing
 
+from PySide6 import QtCore, QtGui, QtWidgets
+
 import cruiz.globals
 from cruiz.constants import DEFAULT_CACHE_NAME
 from cruiz.pyside6.preferences import Ui_PreferencesDialog
@@ -84,8 +86,6 @@ from cruiz.settings.models.recentconanconfigmodel import RecentConanConfigModel
 from cruiz.settings.models.recentconanremotesmodel import RecentConanRemotesModel
 from cruiz.settings.models.recipesmodel import RecipesModel
 from cruiz.widgets.util import BlockSignals, search_for_file_options
-
-from qtpy import QtCore, QtGui, QtWidgets
 
 
 class PreferencesDialog(QtWidgets.QDialog):

--- a/src/cruiz/settings/updatesettings.py
+++ b/src/cruiz/settings/updatesettings.py
@@ -9,7 +9,7 @@ import shutil
 import time
 import typing
 
-from qtpy import QtCore
+from PySide6 import QtCore
 
 from .managers.basesettings import BaseSettings
 

--- a/src/cruiz/svggraph.py
+++ b/src/cruiz/svggraph.py
@@ -7,12 +7,12 @@ from __future__ import annotations
 import os
 import typing
 
+from PySide6 import QtCore, QtGui, QtSvg, QtSvgWidgets, QtWidgets
+
 from cruiz.environ import EnvironSaver
 from cruiz.settings.managers.graphvizpreferences import GraphVizSettingsReader
 
 import graphviz
-
-from qtpy import QtCore, QtGui, QtSvg, QtSvgWidgets, QtWidgets
 
 if typing.TYPE_CHECKING:
     from cruiz.interop.packagenode import PackageNode

--- a/src/cruiz/widgets/aboutcruizdialog.py
+++ b/src/cruiz/widgets/aboutcruizdialog.py
@@ -5,10 +5,10 @@
 import sys
 import typing
 
+from PySide6 import QtCore, QtGui, QtWidgets
+
 from cruiz.pyside6.about_dialog import Ui_AboutCruiz
 from cruiz.version import get_version
-
-from qtpy import QtCore, QtGui, QtWidgets
 
 
 class AboutDialog(QtWidgets.QDialog):
@@ -27,4 +27,4 @@ class AboutDialog(QtWidgets.QDialog):
         self._ui.version.setText(f"Version: {get_version()}")
         self._ui.python.setText(f"Python executable: {sys.executable}")
         self._ui.python_version.setText(f"Python version: {sys.version}")
-        self._ui.pyside_version.setText(f"PySide version: {QtCore.__version__}")
+        self._ui.pyside_version.setText(f"PySide version: {QtCore.qVersion()}")

--- a/src/cruiz/widgets/debugging.py
+++ b/src/cruiz/widgets/debugging.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import typing
 
-from qtpy import QtCore, QtWidgets
+from PySide6 import QtCore, QtWidgets
 
 if typing.TYPE_CHECKING:
     import logging

--- a/src/cruiz/widgets/shortcutlineedit.py
+++ b/src/cruiz/widgets/shortcutlineedit.py
@@ -2,7 +2,7 @@
 
 """QLineEdit that can capture keyboard shortcuts."""
 
-from qtpy import QtCore, QtGui, QtWidgets
+from PySide6 import QtCore, QtGui, QtWidgets
 
 
 class ShortcutLineEdit(QtWidgets.QLineEdit):

--- a/src/cruiz/widgets/util.py
+++ b/src/cruiz/widgets/util.py
@@ -5,7 +5,7 @@
 import platform
 import typing
 
-from qtpy import QtCore, QtWidgets
+from PySide6 import QtCore, QtWidgets
 
 
 def search_for_dir_options() -> QtWidgets.QFileDialog.Option:

--- a/src/cruiz/workers/utils/worker.py
+++ b/src/cruiz/workers/utils/worker.py
@@ -11,13 +11,13 @@ import os
 import traceback
 import typing
 
+from PySide6 import QtCore
+
 from cruiz.interop.commandparameters import CommandParameters
 from cruiz.interop.commonparameters import CommonParameters
 from cruiz.interop.message import Failure, Message, Stdout
 from cruiz.workers.utils.env import clear_conan_env, set_env
 from cruiz.workers.utils.text2html import text_to_html
-
-from qtpy import QtCore
 
 if typing.TYPE_CHECKING:
     from cruiz.interop.searchrecipesparameters import SearchRecipesParameters


### PR DESCRIPTION
This library was useful in the migration from Qt5 to Qt6, but now does not provide any useful features.