### PR TITLE
Fixes #217 Move tested code to cruizlib

### DIFF
--- a/doc/adr/0001-Separate-non-GUI-functionality-into-library.md
+++ b/doc/adr/0001-Separate-non-GUI-functionality-into-library.md
@@ -4,7 +4,7 @@ Date: 2025-01-02
 
 ## Status
 
-Proposed
+Accepted
 
 ## Context
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ cruiz = "cruiz.__main__:main"
 
 [tool.setuptools]
 packages.find.where = ["src"]
-packages.find.include = ["cruiz", "cruiz.*"]
+packages.find.include = ["cruiz", "cruiz.*", "cruizlib", "cruizlib.*"]
 packages.find.exclude = ["cruiz.resources.*"]
 include-package-data = false
 
@@ -134,10 +134,13 @@ deps = [
 commands = [
     ["pip", "install", "-e", "."],
     ["flake8", "src/cruiz"],
+    ["flake8", "src/cruizlib"],
     ["flake8", "tests"],
     ["mypy", "src/cruiz"],
+    ["mypy", "--warn-return-any", "src/cruizlib"],
     ["mypy", "tests"],
     ["pylint", "src/cruiz"],
+    ["pylint", "--enable=all", "src/cruizlib"],
     ["pip", "install", "conan<2"],
     ["pylint", "--ignore-paths=^src/cruiz/pyside6/.*$,^src/cruiz/workers/api/v2/.*$", "src/cruiz"],  # assuming Conan1 APIs
 ]

--- a/src/cruiz/commands/context.py
+++ b/src/cruiz/commands/context.py
@@ -24,12 +24,15 @@ from .metarequestconaninvocation import MetaRequestConanInvocation
 
 if typing.TYPE_CHECKING:
     from cruiz.interop.packagenode import PackageNode
-    from cruiz.interop.pod import ConanRemote, ConanHook
+    from cruiz.interop.pod import ConanRemote
     from cruiz.interop.searchrecipesparameters import SearchRecipesParameters
     from cruiz.interop.reciperevisionsparameters import RecipeRevisionsParameters
     from cruiz.interop.packageidparameters import PackageIdParameters
     from cruiz.interop.packagerevisionsparameters import PackageRevisionsParameters
     from cruiz.interop.packagebinaryparameters import PackageBinaryParameters
+
+    from cruizlib.interop.pod import ConanHook
+
     from .conanconf import ConanConfigBoolean
     from .logdetails import LogDetails
 

--- a/src/cruiz/interop/pod.py
+++ b/src/cruiz/interop/pod.py
@@ -4,7 +4,6 @@
 
 from __future__ import annotations
 
-import pathlib
 import typing
 from dataclasses import dataclass, field
 
@@ -64,37 +63,6 @@ class ConanRemote:
         url = url_arg[1][1:-1]
         enabled = _strtobool(enabled_arg[1])
         return cls(name, url, enabled)
-
-
-@dataclass(frozen=True)
-class ConanHook:
-    """Plain old data class representing a Conan hook."""
-
-    path: pathlib.Path
-    enabled: bool
-
-    def has_path(self, path: pathlib.Path) -> bool:
-        """Return whether the hook contains the specified path."""
-        return self.path in (path, path.stem)
-
-    @classmethod
-    def from_string(cls, string: str) -> ConanHook:
-        """Convert a string to a ConanHook."""
-        assert string.startswith("ConanHook(")
-        assert string.endswith(")")
-        string = string.replace("ConanHook(", "")
-        string = string.rstrip(")")
-        args = string.split(",")
-        assert len(args) == 2
-        # two args, path=ClassName('/path/to'), enabled=True|False
-        path_arg = args[0].strip().replace("path=", "")
-        path_start = path_arg.find("(") + 1
-        path_end = path_arg.find(")")
-        path_arg = path_arg[path_start:path_end][1:-1]
-        path = pathlib.Path(path_arg)
-        enabled_arg = args[1].strip().replace("enabled=", "")
-        enabled = _strtobool(enabled_arg)
-        return cls(path, enabled)
 
 
 @dataclass(frozen=True)

--- a/src/cruiz/manage_local_cache/managelocalcachesdialog.py
+++ b/src/cruiz/manage_local_cache/managelocalcachesdialog.py
@@ -18,7 +18,6 @@ from cruiz.commands.conanconf import ConanConfigBoolean
 from cruiz.commands.context import ConanContext
 from cruiz.commands.logdetails import LogDetails
 from cruiz.constants import DEFAULT_CACHE_NAME
-from cruiz.interop.pod import ConanHook
 from cruiz.pyside6.local_cache_manage import Ui_ManageLocalCaches
 from cruiz.revealonfilesystem import reveal_on_filesystem
 from cruiz.settings.managers.namedlocalcache import (
@@ -34,6 +33,8 @@ from cruiz.settings.managers.recentconanremotes import (
     RecentConanRemotesSettingsWriter,
 )
 from cruiz.widgets.util import BlockSignals
+
+from cruizlib.interop.pod import ConanHook
 
 from .widgets import (
     AddEnvironmentDialog,

--- a/src/cruiz/workers/api/v1/meta.py
+++ b/src/cruiz/workers/api/v1/meta.py
@@ -11,7 +11,9 @@ import typing
 import urllib.parse
 
 from cruiz.interop.message import Failure, Message, Success
-from cruiz.interop.pod import ConanHook, ConanRemote
+from cruiz.interop.pod import ConanRemote
+
+from cruizlib.interop.pod import ConanHook
 
 from . import worker
 

--- a/src/cruiz/workers/api/v2/meta.py
+++ b/src/cruiz/workers/api/v2/meta.py
@@ -15,7 +15,9 @@ import typing
 import urllib.parse
 
 from cruiz.interop.message import Failure, Message, Success
-from cruiz.interop.pod import ConanHook, ConanRemote
+from cruiz.interop.pod import ConanRemote
+
+from cruizlib.interop.pod import ConanHook
 
 from . import worker
 

--- a/src/cruizlib/__init__.py
+++ b/src/cruizlib/__init__.py
@@ -1,0 +1,1 @@
+"""Library for non-GUI components of cruiz."""

--- a/src/cruizlib/interop/__init__.py
+++ b/src/cruizlib/interop/__init__.py
@@ -1,0 +1,1 @@
+"""Utilities for data interop between Conan and the UI."""

--- a/src/cruizlib/interop/pod.py
+++ b/src/cruizlib/interop/pod.py
@@ -1,0 +1,53 @@
+"""Plain old data utilities for interop between Conan and UI."""
+
+from __future__ import annotations
+
+import pathlib
+from dataclasses import dataclass
+
+
+# copied from distutils.url.strtobool and modified
+def _strtobool(val: str) -> bool:
+    """Convert a string representation of truth to true (1) or false (0).
+
+    True values are 'y', 'yes', 't', 'true', 'on', and '1'; false values
+    are 'n', 'no', 'f', 'false', 'off', and '0'.  Raises ValueError if
+    'val' is anything else.
+    """
+    val = val.lower()
+    if val in ("y", "yes", "t", "true", "on", "1"):
+        return True
+    if val in ("n", "no", "f", "false", "off", "0"):
+        return False
+    raise ValueError(f"Invalid truth value {val}")
+
+
+@dataclass(frozen=True)
+class ConanHook:
+    """Plain old data class representing a Conan hook."""
+
+    path: pathlib.Path
+    enabled: bool
+
+    def has_path(self, path: pathlib.Path) -> bool:
+        """Return whether the hook contains the specified path."""
+        return self.path in (path, path.stem)
+
+    @classmethod
+    def from_string(cls, string: str) -> ConanHook:
+        """Convert a string to a ConanHook."""
+        assert string.startswith("ConanHook(")
+        assert string.endswith(")")
+        string = string.replace("ConanHook(", "")
+        string = string.rstrip(")")
+        args = string.split(",")
+        assert len(args) == 2
+        # two args, path=ClassName('/path/to'), enabled=True|False
+        path_arg = args[0].strip().replace("path=", "")
+        path_start = path_arg.find("(") + 1
+        path_end = path_arg.find(")")
+        path_arg = path_arg[path_start:path_end][1:-1]
+        path = pathlib.Path(path_arg)
+        enabled_arg = args[1].strip().replace("enabled=", "")
+        enabled = _strtobool(enabled_arg)
+        return cls(path, enabled)

--- a/tests/interop/test_pod.py
+++ b/tests/interop/test_pod.py
@@ -3,7 +3,7 @@
 import pathlib
 import urllib.parse
 
-from cruiz.interop.pod import ConanHook
+from cruizlib.interop.pod import ConanHook
 
 
 def test_pod_hook_invariant_after_serialization() -> None:


### PR DESCRIPTION
This first introduces the separate cruizlib, which is not to contain any GUI aspects.

Only the ConanHook dataclass is currently tested, so move this over to cruizlib.

mypy and pylint check for any parts of the existing code imports that need changing. mypy and pylint check _more_ for cruizlib since this is new.