### PR TITLE
Fixes #232 Type any cleanup

### DIFF
--- a/src/cruiz/load_recipe/pages/initialprofilepage.py
+++ b/src/cruiz/load_recipe/pages/initialprofilepage.py
@@ -15,13 +15,14 @@ from cruiz.widgets.util import BlockSignals
 
 if typing.TYPE_CHECKING:
     import pathlib
+    from cruiz.pyside6.load_recipe_wizard import Ui_LoadRecipeWizard
 
 
 class LoadRecipeInitialProfilePage(QtWidgets.QWizardPage):
     """Wizard page allowing selection of an initial profile to apply to the recipe."""
 
     @property
-    def _ui(self) -> typing.Any:
+    def _ui(self) -> Ui_LoadRecipeWizard:
         return self.wizard().ui  # type: ignore[attr-defined]
 
     def nextId(self) -> int:

--- a/src/cruiz/load_recipe/pages/localcachepage.py
+++ b/src/cruiz/load_recipe/pages/localcachepage.py
@@ -2,6 +2,8 @@
 
 """Wizard page for selecting a local cache."""
 
+from __future__ import annotations
+
 import typing
 
 from PySide6 import QtWidgets
@@ -11,12 +13,15 @@ from cruiz.settings.managers.namedlocalcache import AllNamedLocalCacheSettingsRe
 from cruiz.settings.managers.recipe import RecipeSettingsReader
 from cruiz.widgets.util import BlockSignals
 
+if typing.TYPE_CHECKING:
+    from cruiz.pyside6.load_recipe_wizard import Ui_LoadRecipeWizard
+
 
 class LoadRecipeLocalCachePage(QtWidgets.QWizardPage):
     """Wizard page for selecting the local cache to associate with the recipe instance."""  # noqa: E501
 
     @property
-    def _ui(self) -> typing.Any:
+    def _ui(self) -> Ui_LoadRecipeWizard:
         return self.wizard().ui  # type: ignore[attr-defined]
 
     def nextId(self) -> int:

--- a/src/cruiz/load_recipe/pages/packageversionpage.py
+++ b/src/cruiz/load_recipe/pages/packageversionpage.py
@@ -2,6 +2,8 @@
 
 """Wizard page for selecting the version of the package."""
 
+from __future__ import annotations
+
 import typing
 
 from PySide6 import QtCore, QtGui, QtWidgets
@@ -11,12 +13,15 @@ from cruiz.settings.managers.conanpreferences import ConanSettingsReader
 from cruiz.settings.managers.recipe import RecipeSettingsReader
 from cruiz.widgets.util import BlockSignals
 
+if typing.TYPE_CHECKING:
+    from cruiz.pyside6.load_recipe_wizard import Ui_LoadRecipeWizard
+
 
 class LoadRecipePackageVersionPage(QtWidgets.QWizardPage):
     """Wizard page for selecting the recipe version to bind to."""
 
     @property
-    def _ui(self) -> typing.Any:
+    def _ui(self) -> Ui_LoadRecipeWizard:
         return self.wizard().ui  # type: ignore[attr-defined]
 
     def nextId(self) -> int:
@@ -87,9 +92,9 @@ class LoadRecipePackageVersionPage(QtWidgets.QWizardPage):
             else:
                 # if the conandata.yml is not available, manually specify a version
                 self._ui.version.setEditable(True)
-                self._ui.version.lineEdit().setPlaceholderText(
-                    "Package version to use, e.g. 1.2.3"
-                )
+                line_edit = self._ui.version.lineEdit()
+                if line_edit is not None:
+                    line_edit.setPlaceholderText("Package version to use, e.g. 1.2.3")
         else:
             with BlockSignals(self._ui.version) as blocked_widget:
                 assert isinstance(blocked_widget, QtWidgets.QComboBox)

--- a/src/cruiz/remote_browser/pages/packagebinarypage.py
+++ b/src/cruiz/remote_browser/pages/packagebinarypage.py
@@ -19,6 +19,9 @@ from cruiz.pyside6.remote_browser_fileview import Ui_remote_browser_fileview
 
 from .page import Page
 
+if typing.TYPE_CHECKING:
+    from cruiz.pyside6.remote_browser import Ui_remotebrowser
+
 
 class _FileNode:
     def __init__(self, path: str, parent: typing.Optional[_FileNode]):
@@ -264,7 +267,7 @@ class _FileViewer(QtWidgets.QDialog):
 class PackageBinaryPage(Page):
     """Remote browser page for displaying package binaries."""
 
-    def setup(self, self_ui: typing.Any) -> None:
+    def setup(self, self_ui: Ui_remotebrowser) -> None:
         """Set up the UI for the page."""
         self._base_setup(self_ui, 4)
         self._current_pkgref: typing.Optional[str] = None
@@ -315,12 +318,9 @@ class PackageBinaryPage(Page):
 
     def _on_back(self) -> None:
         if self._revisions_enabled:
-            self._open_previous_page()
+            self._ui.stackedWidget.setCurrentWidget(self._ui.prev)
         else:
-            # skip package revisions
-            parent_stackedwidget = self.parent()
-            assert isinstance(parent_stackedwidget, QtWidgets.QStackedWidget)
-            parent_stackedwidget.setCurrentIndex(self.page_index - 2)
+            self._ui.stackedWidget.setCurrentWidget(self._ui.package_id)
 
     def _on_prev_dclicked(self, index: QtCore.QModelIndex) -> None:
         node = index.internalPointer()

--- a/src/cruiz/remote_browser/pages/packagereferencepage.py
+++ b/src/cruiz/remote_browser/pages/packagereferencepage.py
@@ -2,6 +2,8 @@
 
 """Remote browser page."""
 
+from __future__ import annotations
+
 import typing
 
 from PySide6 import QtCore, QtGui, QtWidgets
@@ -13,6 +15,9 @@ from cruiz.settings.managers.namedlocalcache import AllNamedLocalCacheSettingsRe
 from cruiz.widgets.util import BlockSignals
 
 from .page import Page
+
+if typing.TYPE_CHECKING:
+    from cruiz.pyside6.remote_browser import Ui_remotebrowser
 
 
 class _PackageReferenceModel(QtCore.QAbstractListModel):
@@ -69,7 +74,7 @@ class _PackageSearchValidator(QtGui.QValidator):
 class PackageReferencePage(Page):
     """Remote browser page for finding package references."""
 
-    def setup(self, self_ui: typing.Any) -> None:
+    def setup(self, self_ui: Ui_remotebrowser) -> None:
         """Set up the UI for the page."""
         self._base_setup(self_ui, 0)
 
@@ -192,12 +197,9 @@ class PackageReferencePage(Page):
     def _on_pkgref_dclicked(self, index: QtCore.QModelIndex) -> None:
         # pylint: disable=unused-argument
         if self._revisions_enabled:
-            self._open_next_page()
+            self._ui.stackedWidget.setCurrentWidget(self._ui.rrev)
         else:
-            # skip recipe revisions
-            parent_stackedwidget = self.parent()
-            assert isinstance(parent_stackedwidget, QtWidgets.QStackedWidget)
-            parent_stackedwidget.setCurrentIndex(self.page_index + 2)
+            self._ui.stackedWidget.setCurrentWidget(self._ui.package_id)
 
     def on_cancel(self) -> None:
         """Call when the user cancels the operation."""

--- a/src/cruiz/remote_browser/pages/packagerevisionpage.py
+++ b/src/cruiz/remote_browser/pages/packagerevisionpage.py
@@ -2,6 +2,8 @@
 
 """Remote browser page."""
 
+from __future__ import annotations
+
 import typing
 
 from PySide6 import QtCore, QtGui, QtWidgets
@@ -9,6 +11,9 @@ from PySide6 import QtCore, QtGui, QtWidgets
 from cruiz.interop.packagerevisionsparameters import PackageRevisionsParameters
 
 from .page import Page
+
+if typing.TYPE_CHECKING:
+    from cruiz.pyside6.remote_browser import Ui_remotebrowser
 
 
 class _PackageRevisionModel(QtCore.QAbstractTableModel):
@@ -63,7 +68,7 @@ class _PackageRevisionModel(QtCore.QAbstractTableModel):
 class PackageRevisionPage(Page):
     """Remote browser page for displaying package revisions."""
 
-    def setup(self, self_ui: typing.Any) -> None:
+    def setup(self, self_ui: Ui_remotebrowser) -> None:
         """Set up the UI for the page."""
         self._base_setup(self_ui, 3)
         self._current_pkgref: typing.Optional[str] = None
@@ -91,6 +96,9 @@ class PackageRevisionPage(Page):
         package_rev = self._model.data(selection[0], QtCore.Qt.ItemDataRole.DisplayRole)
         return f"{self._previous_pkgref}#{package_rev}"
 
+    def _on_copy_pkgref_to_clip(self) -> None:
+        QtWidgets.QApplication.clipboard().setText(self._ui.prev_pkgref.text())
+
     def _enable_progress(self, enable: bool) -> None:
         self._ui.prev_progress.setMaximum(0 if enable else 1)
         self._ui.prev_buttons.setEnabled(not enable)
@@ -115,11 +123,11 @@ class PackageRevisionPage(Page):
             self._current_pkgref = self._previous_pkgref
 
     def _on_back(self) -> None:
-        self._open_previous_page()
+        self._ui.stackedWidget.setCurrentWidget(self._ui.package_id)
 
     def _on_prev_dclicked(self, index: QtCore.QModelIndex) -> None:
         # pylint: disable=unused-argument
-        self._open_next_page()
+        self._ui.stackedWidget.setCurrentWidget(self._ui.pbinary)
 
     def on_cancel(self) -> None:
         """Call when the user cancels the operation."""
@@ -145,6 +153,3 @@ class PackageRevisionPage(Page):
 
     def _on_restart(self) -> None:
         self._open_start()
-
-    def _on_copy_pkgref_to_clip(self) -> None:
-        QtWidgets.QApplication.clipboard().setText(self._ui.prev_pkgref.text())

--- a/src/cruiz/remote_browser/pages/page.py
+++ b/src/cruiz/remote_browser/pages/page.py
@@ -4,53 +4,62 @@
 
 from __future__ import annotations
 
+import abc
 import typing
 
 from PySide6 import QtCore, QtGui, QtWidgets
 
+
 if typing.TYPE_CHECKING:
     from cruiz.commands.context import ConanContext
     from cruiz.commands.logdetails import LogDetails
+    from cruiz.pyside6.remote_browser import Ui_remotebrowser
+    from cruiz.remote_browser.remotebrowser import RemoteBrowserDock
 
 
 class Page(QtWidgets.QWidget):
     """Base class for all pages shown in the remote browser."""
 
-    def _base_setup(self, self_ui: typing.Any, index: int) -> None:
+    def _base_setup(self, self_ui: Ui_remotebrowser, index: int) -> None:
         self._ui = self_ui
         self.page_index = index
 
     @property
+    @abc.abstractmethod
+    def package_reference(self) -> str:
+        """Get the package reference with all details on the current page."""
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def _on_copy_pkgref_to_clip(self) -> None:
+        """Copy the package reference with all details on the current page to the clipboard."""  # noqa: E501
+        raise NotImplementedError()
+
+    @property
     def _log_details(self) -> LogDetails:
-        stacked_widget = self.parent()
-        dock_contents = stacked_widget.parent()
-        remote_browser = dock_contents.parent()
+        remote_browser: RemoteBrowserDock = self._ui.dockWidgetContents.parent()  # type: ignore[assignment]  # noqa: E501
         # pylint: disable=protected-access
         # TODO: this is non-public access as is just forwarding the parent's details
-        return remote_browser._log_details  # type: ignore[attr-defined]
+        return remote_browser._log_details
 
     @property
     def _context(self) -> ConanContext:
-        stacked_widget = self.parent()
-        dock_contents = stacked_widget.parent()
-        remote_browser = dock_contents.parent()
+        remote_browser: RemoteBrowserDock = self._ui.dockWidgetContents.parent()  # type: ignore[assignment]  # noqa: E501
         # pylint: disable=protected-access
         # TODO: this is non-public access as is just forwarding the parent's details
-        return remote_browser._context  # type: ignore[attr-defined]
+        return remote_browser._context
 
+    # TODO: does this belong in the parent?
     @property
     def _revisions_enabled(self) -> bool:
-        stacked_widget = self.parent()
-        assert isinstance(stacked_widget, QtWidgets.QStackedWidget)
-        pkgref_page = stacked_widget.widget(0)
         # pylint: disable=protected-access
         # TODO: this is non-public access as is just forwarding the parent's details
-        return pkgref_page._revs_enabled  # type: ignore[attr-defined]
+        return self._ui.pkgref._revs_enabled
 
     def _on_pkgref_menu(self, position: QtCore.QPoint) -> None:
         menu = QtWidgets.QMenu(self)
         copy_action = QtGui.QAction("Copy to clipboard", self)
-        copy_action.triggered.connect(self._on_copy_pkgref_to_clip)  # type: ignore[attr-defined] # noqa: E501
+        copy_action.triggered.connect(self._on_copy_pkgref_to_clip)
         menu.addAction(copy_action)
         sender_label = self.sender()
         assert isinstance(sender_label, QtWidgets.QLabel)
@@ -66,32 +75,19 @@ class Page(QtWidgets.QWidget):
         menu.exec_(sender_tableview.mapToGlobal(position))
 
     def _on_copy_selected_pkgref_to_clip(self) -> None:
-        QtWidgets.QApplication.clipboard().setText(self.package_reference)  # type: ignore[attr-defined] # noqa: E501
+        QtWidgets.QApplication.clipboard().setText(self.package_reference)
 
     def _open_start(self) -> None:
-        stacked_widget = self.parent()
-        assert isinstance(stacked_widget, QtWidgets.QStackedWidget)
-        stacked_widget.setCurrentIndex(0)
-        stacked_widget.widget(0).invalidate()  # type: ignore[attr-defined]
-
-    def _open_previous_page(self) -> None:
-        parent_stackedwidget = self.parent()
-        assert isinstance(parent_stackedwidget, QtWidgets.QStackedWidget)
-        parent_stackedwidget.setCurrentIndex(self.page_index - 1)
-
-    def _open_next_page(self) -> None:
-        parent_stackedwidget = self.parent()
-        assert isinstance(parent_stackedwidget, QtWidgets.QStackedWidget)
-        parent_stackedwidget.setCurrentIndex(self.page_index + 1)
+        self._ui.stackedWidget.setCurrentWidget(self._ui.pkgref)
+        self._ui.pkgref.invalidate()
 
     @property
-    def _previous_page(self) -> QtWidgets.QWidget:
-        stacked_widget = self.parent()
-        assert isinstance(stacked_widget, QtWidgets.QStackedWidget)
-        if self._revisions_enabled:
-            return stacked_widget.widget(self.page_index - 1)
-        return stacked_widget.widget(self.page_index - 2)
+    def _previous_page(self) -> Page:
+        index_offset = -1 if self._revisions_enabled else -2
+        page = self._ui.stackedWidget.widget(self.page_index + index_offset)
+        assert isinstance(page, Page)
+        return page
 
     @property
     def _previous_pkgref(self) -> str:
-        return self._previous_page.package_reference  # type: ignore[attr-defined] # noqa: E501
+        return self._previous_page.package_reference

--- a/src/cruiz/remote_browser/pages/reciperevisionpage.py
+++ b/src/cruiz/remote_browser/pages/reciperevisionpage.py
@@ -2,6 +2,8 @@
 
 """Remote browser page."""
 
+from __future__ import annotations
+
 import typing
 
 from PySide6 import QtCore, QtGui, QtWidgets
@@ -9,6 +11,9 @@ from PySide6 import QtCore, QtGui, QtWidgets
 from cruiz.interop.reciperevisionsparameters import RecipeRevisionsParameters
 
 from .page import Page
+
+if typing.TYPE_CHECKING:
+    from cruiz.pyside6.remote_browser import Ui_remotebrowser
 
 
 class _RecipeRevisionModel(QtCore.QAbstractTableModel):
@@ -63,7 +68,7 @@ class _RecipeRevisionModel(QtCore.QAbstractTableModel):
 class RecipeRevisionPage(Page):
     """Remote browser page for recipe revisions."""
 
-    def setup(self, self_ui: typing.Any) -> None:
+    def setup(self, self_ui: Ui_remotebrowser) -> None:
         """Set up the UI for the page."""
         self._base_setup(self_ui, 1)
         self._current_pkgref: typing.Optional[str] = None
@@ -90,6 +95,9 @@ class RecipeRevisionPage(Page):
         rrev = self._model.data(selection[0], QtCore.Qt.ItemDataRole.DisplayRole)
         return f"{self._previous_pkgref}#{rrev}"
 
+    def _on_copy_pkgref_to_clip(self) -> None:
+        QtWidgets.QApplication.clipboard().setText(self._ui.rrev_pkgref.text())
+
     def _enable_progress(self, enable: bool) -> None:
         self._ui.rrev_progress.setMaximum(0 if enable else 1)
         self._ui.rrev_buttons.setEnabled(not enable)
@@ -114,11 +122,11 @@ class RecipeRevisionPage(Page):
             self._current_pkgref = self._previous_pkgref
 
     def _on_back(self) -> None:
-        self._open_previous_page()
+        self._ui.stackedWidget.setCurrentWidget(self._ui.pkgref)
 
     def _on_rrev_dclicked(self, index: QtCore.QModelIndex) -> None:
         # pylint: disable=unused-argument
-        self._open_next_page()
+        self._ui.stackedWidget.setCurrentWidget(self._ui.package_id)
 
     def on_cancel(self) -> None:
         """Call when the user cancels the operation."""
@@ -141,6 +149,3 @@ class RecipeRevisionPage(Page):
                 remote_name=self._ui.remote.currentText(),
             )
             self._context.get_package_details(params, self._complete)
-
-    def _on_copy_pkgref_to_clip(self) -> None:
-        QtWidgets.QApplication.clipboard().setText(self._ui.rrev_pkgref.text())


### PR DESCRIPTION
Using `typing.TYPE_CHECKING` allows some more accurate type usage in some cases.