### PR TITLE
Fixes #258 Move ExtraProfileDirectory to cruilib, drop unused LocalCa…

### DIFF
--- a/src/cruiz/interop/pod.py
+++ b/src/cruiz/interop/pod.py
@@ -4,25 +4,9 @@
 
 from __future__ import annotations
 
-import typing
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 
 from attrs.converters import to_bool
-
-
-@dataclass(frozen=True)
-class LocalCacheDetails:
-    """Plain old data class representing Conan local cache details."""
-
-    home_directory: typing.Optional[str] = None
-    short_home_directory: typing.Optional[str] = None
-    extra_profile_directories: typing.List[ExtraProfileDirectory] = field(
-        default_factory=list
-    )
-    environment: typing.Dict[str, str] = field(default_factory=dict)
-    # TODO: the following are deprecated and will be removed in future
-    v2_mode: typing.Optional[bool] = None
-    use_revisions: typing.Optional[bool] = None
 
 
 @dataclass(frozen=True)
@@ -49,11 +33,3 @@ class ConanRemote:
         url = url_arg[1][1:-1]
         enabled = to_bool(enabled_arg[1])
         return cls(name, url, enabled)
-
-
-@dataclass(frozen=True)
-class ExtraProfileDirectory:
-    """Plain old data class representing an additional profile directory."""
-
-    name: str
-    directory: str

--- a/src/cruiz/manage_local_cache/widgets/addextraprofiledirectorydialog.py
+++ b/src/cruiz/manage_local_cache/widgets/addextraprofiledirectorydialog.py
@@ -6,11 +6,12 @@ import typing
 
 from PySide6 import QtCore, QtGui, QtWidgets
 
-from cruiz.interop.pod import ExtraProfileDirectory
 from cruiz.pyside6.local_cache_add_profile_directory import (
     Ui_AddExtraProfileDirectoryDialog,
 )
 from cruiz.widgets.util import search_for_dir_options
+
+from cruizlib.interop.pod import ExtraProfileDirectory
 
 
 class AddExtraProfileDirectoryDialog(QtWidgets.QDialog):

--- a/src/cruiz/settings/managers/namedlocalcache.py
+++ b/src/cruiz/settings/managers/namedlocalcache.py
@@ -18,7 +18,7 @@ from .valueclasses import DictValue, ListValue, ScalarValue
 from .writermixin import _WriterMixin
 
 if typing.TYPE_CHECKING:
-    from cruiz.interop.pod import ExtraProfileDirectory
+    from cruizlib.interop.pod import ExtraProfileDirectory
 
 
 # TODO: this needs some work as there is a lot of repetition

--- a/src/cruizlib/interop/pod.py
+++ b/src/cruizlib/interop/pod.py
@@ -37,3 +37,11 @@ class ConanHook:
         enabled_arg = args[1].strip().replace("enabled=", "")
         enabled = to_bool(enabled_arg)
         return cls(path, enabled)
+
+
+@dataclass(frozen=True)
+class ExtraProfileDirectory:
+    """Plain old data class representing an additional profile directory."""
+
+    name: str
+    directory: str


### PR DESCRIPTION
…cheDetails

Migration of more code to cruizlib.

ExtraProfileDirectory does not have any functionality, so no tests required.