### PR TITLE
Refactor: Moved cruiz.interop.message to cruizlib.

### DIFF
--- a/src/cruiz/commands/messagereplyprocessor.py
+++ b/src/cruiz/commands/messagereplyprocessor.py
@@ -17,7 +17,8 @@ from PySide6 import QtCore
 
 import cruiz.workers.api as workers_api
 from cruiz.dumpobjecttypes import dump_object_types
-from cruiz.interop.message import (
+
+from cruizlib.interop.message import (
     ConanLogMessage,
     End,
     Failure,

--- a/src/cruiz/commands/metarequestconaninvocation.py
+++ b/src/cruiz/commands/metarequestconaninvocation.py
@@ -20,7 +20,8 @@ from PySide6 import QtCore
 import cruiz.workers.api as workers_api
 from cruiz.dumpobjecttypes import dump_object_types
 from cruiz.interop.commandparameters import CommandParameters
-from cruiz.interop.message import (
+
+from cruizlib.interop.message import (
     ConanLogMessage,
     Failure,
     Stderr,

--- a/src/cruiz/workers/api/common/endmessagethread.py
+++ b/src/cruiz/workers/api/common/endmessagethread.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import typing
 
-from cruiz.interop.message import End, Message
+from cruizlib.interop.message import End, Message
 
 if typing.TYPE_CHECKING:
     import multiprocessing

--- a/src/cruiz/workers/api/v1/arbitrary.py
+++ b/src/cruiz/workers/api/v1/arbitrary.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import typing
 
-from cruiz.interop.message import Message, Success
+from cruizlib.interop.message import Message, Success
 
 from . import worker
 

--- a/src/cruiz/workers/api/v1/build.py
+++ b/src/cruiz/workers/api/v1/build.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import typing
 
-from cruiz.interop.message import Message, Success
+from cruizlib.interop.message import Message, Success
 
 from . import worker
 

--- a/src/cruiz/workers/api/v1/cmakebuildtool.py
+++ b/src/cruiz/workers/api/v1/cmakebuildtool.py
@@ -8,8 +8,9 @@ import multiprocessing
 import typing
 
 import cruiz.runcommands
-from cruiz.interop.message import Message, Stderr, Stdout, Success
 from cruiz.workers.utils.worker import Worker
+
+from cruizlib.interop.message import Message, Stderr, Stdout, Success
 
 if typing.TYPE_CHECKING:
     from cruiz.interop.commandparameters import CommandParameters

--- a/src/cruiz/workers/api/v1/conanapi.py
+++ b/src/cruiz/workers/api/v1/conanapi.py
@@ -18,10 +18,10 @@ from conans.client import conan_api, output, runner  # noqa: E402, I100
 from conans.paths import get_conan_user_home  # noqa: E402
 
 from cruiz.interop.commandparameters import CommandParameters  # noqa: E402
-from cruiz.interop.message import Message, Stderr, Stdout  # noqa: E402
 from cruiz.workers.utils.stream import QueuedStreamSix  # noqa: E402
 
 from cruizlib.interop.commonparameters import CommonParameters  # noqa: E402
+from cruizlib.interop.message import Message, Stderr, Stdout  # noqa: E402
 
 from .qtlogger import QtLogger  # noqa: E402
 

--- a/src/cruiz/workers/api/v1/configinstall.py
+++ b/src/cruiz/workers/api/v1/configinstall.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import typing
 from io import StringIO
 
-from cruiz.interop.message import Message, Stdout, Success
+from cruizlib.interop.message import Message, Stdout, Success
 
 from . import worker
 

--- a/src/cruiz/workers/api/v1/create.py
+++ b/src/cruiz/workers/api/v1/create.py
@@ -6,8 +6,9 @@ from __future__ import annotations
 
 import typing
 
-from cruiz.interop.message import Message, Success
 from cruiz.workers.utils.formatoptions import format_options
+
+from cruizlib.interop.message import Message, Success
 
 from . import worker
 

--- a/src/cruiz/workers/api/v1/deletecmakecache.py
+++ b/src/cruiz/workers/api/v1/deletecmakecache.py
@@ -7,8 +7,9 @@ from __future__ import annotations
 import typing
 from pathlib import Path
 
-from cruiz.interop.message import Message, Stdout, Success
 from cruiz.workers.utils.worker import Worker
+
+from cruizlib.interop.message import Message, Stdout, Success
 
 if typing.TYPE_CHECKING:
     import multiprocessing

--- a/src/cruiz/workers/api/v1/exportpackage.py
+++ b/src/cruiz/workers/api/v1/exportpackage.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import typing
 
-from cruiz.interop.message import Message, Success
+from cruizlib.interop.message import Message, Success
 
 from . import worker
 

--- a/src/cruiz/workers/api/v1/imports.py
+++ b/src/cruiz/workers/api/v1/imports.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import typing
 
-from cruiz.interop.message import Message, Success
+from cruizlib.interop.message import Message, Success
 
 from . import worker
 

--- a/src/cruiz/workers/api/v1/install.py
+++ b/src/cruiz/workers/api/v1/install.py
@@ -6,8 +6,9 @@ from __future__ import annotations
 
 import typing
 
-from cruiz.interop.message import Message, Success
 from cruiz.workers.utils.formatoptions import format_options
+
+from cruizlib.interop.message import Message, Success
 
 from . import worker
 

--- a/src/cruiz/workers/api/v1/lockcreate.py
+++ b/src/cruiz/workers/api/v1/lockcreate.py
@@ -7,9 +7,10 @@ from __future__ import annotations
 import typing
 
 from cruiz.interop.dependencygraph import DependencyGraph
-from cruiz.interop.message import Message, Success
 from cruiz.interop.packagenode import PackageNode
 from cruiz.workers.utils.formatoptions import format_options
+
+from cruizlib.interop.message import Message, Success
 
 from . import worker
 

--- a/src/cruiz/workers/api/v1/meta.py
+++ b/src/cruiz/workers/api/v1/meta.py
@@ -12,9 +12,9 @@ import urllib.parse
 
 from attrs.converters import to_bool
 
-from cruiz.interop.message import Failure, Message, Success
 from cruiz.interop.pod import ConanRemote
 
+from cruizlib.interop.message import Failure, Message, Success
 from cruizlib.interop.pod import ConanHook
 
 from . import worker

--- a/src/cruiz/workers/api/v1/package.py
+++ b/src/cruiz/workers/api/v1/package.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import typing
 
-from cruiz.interop.message import Message, Success
+from cruizlib.interop.message import Message, Success
 
 from . import worker
 

--- a/src/cruiz/workers/api/v1/packagebinary.py
+++ b/src/cruiz/workers/api/v1/packagebinary.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import typing
 
-from cruiz.interop.message import Message, Success
+from cruizlib.interop.message import Message, Success
 
 from . import worker
 

--- a/src/cruiz/workers/api/v1/packagedetails.py
+++ b/src/cruiz/workers/api/v1/packagedetails.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import multiprocessing
 import typing
 
-from cruiz.interop.message import Message, Success
+from cruizlib.interop.message import Message, Success
 
 from . import worker
 

--- a/src/cruiz/workers/api/v1/packagerevisions.py
+++ b/src/cruiz/workers/api/v1/packagerevisions.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import typing
 
-from cruiz.interop.message import Message, Success
+from cruizlib.interop.message import Message, Success
 
 from . import worker
 

--- a/src/cruiz/workers/api/v1/qtlogger.py
+++ b/src/cruiz/workers/api/v1/qtlogger.py
@@ -10,7 +10,7 @@ import typing
 
 import conans.util.log
 
-from cruiz.interop.message import ConanLogMessage, Message
+from cruizlib.interop.message import ConanLogMessage, Message
 
 
 class _Singleton(type):

--- a/src/cruiz/workers/api/v1/reciperevisions.py
+++ b/src/cruiz/workers/api/v1/reciperevisions.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import typing
 
-from cruiz.interop.message import Message, Success
+from cruizlib.interop.message import Message, Success
 
 from . import worker
 

--- a/src/cruiz/workers/api/v1/remotesearch.py
+++ b/src/cruiz/workers/api/v1/remotesearch.py
@@ -8,7 +8,7 @@ import multiprocessing
 import re
 import typing
 
-from cruiz.interop.message import Message, Success
+from cruizlib.interop.message import Message, Success
 
 from . import worker
 

--- a/src/cruiz/workers/api/v1/removeallpackages.py
+++ b/src/cruiz/workers/api/v1/removeallpackages.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import typing
 
-from cruiz.interop.message import Message, Stdout, Success
+from cruizlib.interop.message import Message, Stdout, Success
 
 from . import worker
 

--- a/src/cruiz/workers/api/v1/removelocks.py
+++ b/src/cruiz/workers/api/v1/removelocks.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import typing
 
-from cruiz.interop.message import Message, Success
+from cruizlib.interop.message import Message, Success
 
 from . import worker
 

--- a/src/cruiz/workers/api/v1/removepackage.py
+++ b/src/cruiz/workers/api/v1/removepackage.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import typing
 
-from cruiz.interop.message import Message, Stdout, Success
+from cruizlib.interop.message import Message, Stdout, Success
 
 from . import worker
 

--- a/src/cruiz/workers/api/v1/source.py
+++ b/src/cruiz/workers/api/v1/source.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import typing
 
-from cruiz.interop.message import Message, Success
+from cruizlib.interop.message import Message, Success
 
 from . import worker
 

--- a/src/cruiz/workers/api/v1/testpackage.py
+++ b/src/cruiz/workers/api/v1/testpackage.py
@@ -6,8 +6,9 @@ from __future__ import annotations
 
 import typing
 
-from cruiz.interop.message import Message, Success
 from cruiz.workers.utils.formatoptions import format_options
+
+from cruizlib.interop.message import Message, Success
 
 from . import worker
 

--- a/src/cruiz/workers/api/v2/arbitrary.py
+++ b/src/cruiz/workers/api/v2/arbitrary.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import multiprocessing
 import typing
 
-from cruiz.interop.message import Failure, Message, Success
+from cruizlib.interop.message import Failure, Message, Success
 
 from . import worker
 

--- a/src/cruiz/workers/api/v2/build.py
+++ b/src/cruiz/workers/api/v2/build.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import multiprocessing
 import typing
 
-from cruiz.interop.message import Message, Success
+from cruizlib.interop.message import Message, Success
 
 from . import worker
 

--- a/src/cruiz/workers/api/v2/configinstall.py
+++ b/src/cruiz/workers/api/v2/configinstall.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import typing
 from io import StringIO
 
-from cruiz.interop.message import Message, Stdout, Success
+from cruizlib.interop.message import Message, Stdout, Success
 
 from . import worker
 

--- a/src/cruiz/workers/api/v2/create.py
+++ b/src/cruiz/workers/api/v2/create.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import multiprocessing
 import typing
 
-from cruiz.interop.message import Message, Success
+from cruizlib.interop.message import Message, Success
 
 from . import worker
 

--- a/src/cruiz/workers/api/v2/exportpackage.py
+++ b/src/cruiz/workers/api/v2/exportpackage.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import multiprocessing
 import typing
 
-from cruiz.interop.message import Message, Success
+from cruizlib.interop.message import Message, Success
 
 from . import worker
 

--- a/src/cruiz/workers/api/v2/install.py
+++ b/src/cruiz/workers/api/v2/install.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import multiprocessing
 import typing
 
-from cruiz.interop.message import Message, Success
+from cruizlib.interop.message import Message, Success
 
 from . import worker
 

--- a/src/cruiz/workers/api/v2/lockcreate.py
+++ b/src/cruiz/workers/api/v2/lockcreate.py
@@ -8,9 +8,10 @@ import multiprocessing
 import typing
 
 from cruiz.interop.dependencygraph import DependencyGraph
-from cruiz.interop.message import Message, Success
 from cruiz.interop.packagenode import PackageNode
 from cruiz.workers.utils.formatoptions import format_options_v2
+
+from cruizlib.interop.message import Message, Success
 
 from . import worker
 

--- a/src/cruiz/workers/api/v2/meta.py
+++ b/src/cruiz/workers/api/v2/meta.py
@@ -14,9 +14,9 @@ import pathlib
 import typing
 import urllib.parse
 
-from cruiz.interop.message import Failure, Message, Success
 from cruiz.interop.pod import ConanRemote
 
+from cruizlib.interop.message import Failure, Message, Success
 from cruizlib.interop.pod import ConanHook
 
 from . import worker

--- a/src/cruiz/workers/api/v2/packagebinary.py
+++ b/src/cruiz/workers/api/v2/packagebinary.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import typing
 
-from cruiz.interop.message import Message, Success
+from cruizlib.interop.message import Message, Success
 
 from . import worker
 

--- a/src/cruiz/workers/api/v2/packagedetails.py
+++ b/src/cruiz/workers/api/v2/packagedetails.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import typing
 
-from cruiz.interop.message import Message, Success
+from cruizlib.interop.message import Message, Success
 
 from . import worker
 

--- a/src/cruiz/workers/api/v2/packagerevisions.py
+++ b/src/cruiz/workers/api/v2/packagerevisions.py
@@ -8,7 +8,7 @@ import datetime
 import multiprocessing
 import typing
 
-from cruiz.interop.message import Message, Success
+from cruizlib.interop.message import Message, Success
 
 from . import worker
 

--- a/src/cruiz/workers/api/v2/reciperevisions.py
+++ b/src/cruiz/workers/api/v2/reciperevisions.py
@@ -8,7 +8,7 @@ import datetime
 import multiprocessing
 import typing
 
-from cruiz.interop.message import Message, Success
+from cruizlib.interop.message import Message, Success
 
 from . import worker
 

--- a/src/cruiz/workers/api/v2/remotesearch.py
+++ b/src/cruiz/workers/api/v2/remotesearch.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import typing
 
-from cruiz.interop.message import Message, Success
+from cruizlib.interop.message import Message, Success
 
 from . import worker
 

--- a/src/cruiz/workers/api/v2/removeallpackages.py
+++ b/src/cruiz/workers/api/v2/removeallpackages.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import typing
 
-from cruiz.interop.message import Message, Stdout, Success
+from cruizlib.interop.message import Message, Stdout, Success
 
 from . import worker
 

--- a/src/cruiz/workers/api/v2/removepackage.py
+++ b/src/cruiz/workers/api/v2/removepackage.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import typing
 
-from cruiz.interop.message import Message, Stdout, Success
+from cruizlib.interop.message import Message, Stdout, Success
 
 from . import worker
 

--- a/src/cruiz/workers/api/v2/source.py
+++ b/src/cruiz/workers/api/v2/source.py
@@ -8,7 +8,7 @@ import multiprocessing
 import os
 import typing
 
-from cruiz.interop.message import Message, Success
+from cruizlib.interop.message import Message, Success
 
 from . import worker
 

--- a/src/cruiz/workers/api/v2/testpackage.py
+++ b/src/cruiz/workers/api/v2/testpackage.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import multiprocessing
 import typing
 
-from cruiz.interop.message import Message, Success
+from cruizlib.interop.message import Message, Success
 
 from . import worker
 

--- a/src/cruiz/workers/api/v2/worker.py
+++ b/src/cruiz/workers/api/v2/worker.py
@@ -8,9 +8,10 @@ import multiprocessing
 import typing
 
 import cruiz.runcommands
-from cruiz.interop.message import Message, Stderr, Stdout
 from cruiz.workers.utils.stream import QueuedStreamSix
 from cruiz.workers.utils.worker import Worker
+
+from cruizlib.interop.message import Message, Stderr, Stdout
 
 
 def _patch_conan_output_initialiser(queue: multiprocessing.Queue[Message]) -> None:

--- a/src/cruiz/workers/utils/stream.py
+++ b/src/cruiz/workers/utils/stream.py
@@ -12,7 +12,7 @@ import six
 from .colorarma_conversion import convert_from_colorama_to_html
 
 if typing.TYPE_CHECKING:
-    from cruiz.interop.message import Message
+    from cruizlib.interop.message import Message
 
 
 class QueuedStreamSix(six.StringIO):

--- a/src/cruiz/workers/utils/worker.py
+++ b/src/cruiz/workers/utils/worker.py
@@ -14,11 +14,11 @@ import typing
 from PySide6 import QtCore
 
 from cruiz.interop.commandparameters import CommandParameters
-from cruiz.interop.message import Failure, Message, Stdout
 from cruiz.workers.utils.env import clear_conan_env, set_env
 from cruiz.workers.utils.text2html import text_to_html
 
 from cruizlib.interop.commonparameters import CommonParameters
+from cruizlib.interop.message import Failure, Message, Stdout
 
 if typing.TYPE_CHECKING:
     from cruiz.interop.packagebinaryparameters import PackageBinaryParameters

--- a/src/cruizlib/interop/message.py
+++ b/src/cruizlib/interop/message.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+# pylint: disable=too-few-public-methods
+
 """Conan interop message."""
 
 import typing

--- a/tests/interop/test_imports.py
+++ b/tests/interop/test_imports.py
@@ -5,6 +5,7 @@ import sys
 
 MODULES_TO_IMPORT = (
     "cruizlib.interop.commonparameters",
+    "cruizlib.interop.message",
     "cruizlib.interop.pod",
 )
 

--- a/tests/interop/test_message.py
+++ b/tests/interop/test_message.py
@@ -1,0 +1,23 @@
+"""Tests for messages."""
+
+import cruizlib.interop.message
+
+
+def test_message_extraction() -> None:
+    """Message type extraction."""
+    stdout = cruizlib.interop.message.Stdout("This is stdout")
+    assert stdout.message() == "This is stdout"
+
+    stderr = cruizlib.interop.message.Stderr("This is stderr")
+    assert stderr.message() == "This is stderr"
+
+    log = cruizlib.interop.message.ConanLogMessage("This is ConanLogMessage")
+    assert log.message() == "This is ConanLogMessage"
+
+    success = cruizlib.interop.message.Success(1)
+    assert isinstance(success.payload(), int)
+    assert success.payload() == 1
+
+    failure = cruizlib.interop.message.Failure(RuntimeError("This Failed"))
+    assert isinstance(failure.exception(), RuntimeError)
+    assert str(failure.exception()) == "This Failed"


### PR DESCRIPTION
Added test.

Suppressed pylint's too-few-public-methods for this file. Did this in the specific Python module, instead of on the pytest command line so the scope is more limited.