### PR TITLE
Refactor: Move CommandParameters to cruizlib

### DIFF
--- a/src/cruiz/commands/conaninvocation.py
+++ b/src/cruiz/commands/conaninvocation.py
@@ -26,12 +26,13 @@ import psutil
 from .messagereplyprocessor import MessageReplyProcessor
 
 if typing.TYPE_CHECKING:
-    from cruiz.interop.commandparameters import CommandParameters
     from cruiz.interop.packagebinaryparameters import PackageBinaryParameters
     from cruiz.interop.packageidparameters import PackageIdParameters
     from cruiz.interop.packagerevisionsparameters import PackageRevisionsParameters
     from cruiz.interop.reciperevisionsparameters import RecipeRevisionsParameters
     from cruiz.interop.searchrecipesparameters import SearchRecipesParameters
+
+    from cruizlib.interop.commandparameters import CommandParameters
 
     from .logdetails import LogDetails
 

--- a/src/cruiz/commands/context.py
+++ b/src/cruiz/commands/context.py
@@ -15,11 +15,11 @@ from attr.converters import to_bool
 
 import cruiz.workers.api as workers_api
 from cruiz.exceptions import RecipeInspectionError
-from cruiz.interop.commandparameters import CommandParameters
 from cruiz.recipe.logs.command import CommandListWidgetItem, RecipeCommandHistoryWidget
 from cruiz.settings.managers.namedlocalcache import NamedLocalCacheSettingsReader
 
 from cruizlib.constants import DEFAULT_CACHE_NAME
+from cruizlib.interop.commandparameters import CommandParameters
 
 from .conanenv import get_conan_env
 from .conaninvocation import ConanInvocation

--- a/src/cruiz/commands/metarequestconaninvocation.py
+++ b/src/cruiz/commands/metarequestconaninvocation.py
@@ -19,8 +19,8 @@ from PySide6 import QtCore
 
 import cruiz.workers.api as workers_api
 from cruiz.dumpobjecttypes import dump_object_types
-from cruiz.interop.commandparameters import CommandParameters
 
+from cruizlib.interop.commandparameters import CommandParameters
 from cruizlib.interop.message import (
     ConanLogMessage,
     Failure,

--- a/src/cruiz/manage_local_cache/widgets/installconfigdialog.py
+++ b/src/cruiz/manage_local_cache/widgets/installconfigdialog.py
@@ -10,13 +10,14 @@ from functools import partial
 from PySide6 import QtCore, QtGui, QtWidgets
 
 import cruiz.workers.api as workers_api
-from cruiz.interop.commandparameters import CommandParameters
 from cruiz.pyside6.local_cache_install_config import Ui_InstallConfigDialog
 from cruiz.settings.managers.recentconanconfigs import (
     RecentConanConfigSettings,
     RecentConanConfigSettingsReader,
     RecentConanConfigSettingsWriter,
 )
+
+from cruizlib.interop.commandparameters import CommandParameters
 
 if typing.TYPE_CHECKING:
     from cruiz.commands.context import ConanContext

--- a/src/cruiz/manage_local_cache/widgets/newlocalcachewizard.py
+++ b/src/cruiz/manage_local_cache/widgets/newlocalcachewizard.py
@@ -10,7 +10,6 @@ from PySide6 import QtGui, QtWidgets
 import cruiz.workers.api as workers_api
 from cruiz.commands.context import ConanContext
 from cruiz.commands.logdetails import LogDetails
-from cruiz.interop.commandparameters import CommandParameters
 from cruiz.pyside6.local_cache_new_wizard import Ui_NewLocalCacheWizard
 from cruiz.settings.managers.localcachepreferences import LocalCacheSettingsReader
 from cruiz.settings.managers.namedlocalcache import NamedLocalCacheCreator
@@ -18,6 +17,7 @@ from cruiz.widgets.util import search_for_dir_options
 
 import cruizlib.globals
 from cruizlib.constants import DEFAULT_CACHE_NAME
+from cruizlib.interop.commandparameters import CommandParameters
 
 
 class NewLocalCacheWizard(QtWidgets.QWizard):

--- a/src/cruiz/manage_local_cache/widgets/runconancommanddialog.py
+++ b/src/cruiz/manage_local_cache/widgets/runconancommanddialog.py
@@ -9,10 +9,10 @@ from PySide6 import QtCore, QtWidgets
 import cruiz.workers.api as workers_api
 from cruiz.commands.context import ConanContext
 from cruiz.commands.logdetails import LogDetails
-from cruiz.interop.commandparameters import CommandParameters
 from cruiz.pyside6.local_cache_run_command_dialog import Ui_RunConanCommandDialog
 
 import cruizlib.globals
+from cruizlib.interop.commandparameters import CommandParameters
 
 
 class RunConanCommandDialog(QtWidgets.QDialog):

--- a/src/cruiz/recipe/logs/command.py
+++ b/src/cruiz/recipe/logs/command.py
@@ -11,7 +11,7 @@ import typing
 from PySide6 import QtCore, QtGui, QtWidgets
 
 if typing.TYPE_CHECKING:
-    from cruiz.interop.commandparameters import CommandParameters
+    from cruizlib.interop.commandparameters import CommandParameters
 
 
 class CommandListWidgetItem(QtWidgets.QListWidgetItem):

--- a/src/cruiz/recipe/recipewidget.py
+++ b/src/cruiz/recipe/recipewidget.py
@@ -17,7 +17,6 @@ import cruiz.workers.api as workers_api
 from cruiz.commands.context import ConanContext
 from cruiz.commands.logdetails import LogDetails
 from cruiz.exceptions import RecipeInspectionError
-from cruiz.interop.commandparameters import CommandParameters
 from cruiz.manage_local_cache import ManageLocalCachesDialog
 from cruiz.model.graphaslistmodel import DependenciesListModel, DependenciesTreeModel
 from cruiz.pyside6.recipe_window import Ui_RecipeWindow
@@ -34,6 +33,7 @@ from cruiz.settings.managers.recipe import (
 from cruiz.widgets.util import BlockSignals, clear_widgets_from_layout
 
 import cruizlib.globals
+from cruizlib.interop.commandparameters import CommandParameters
 from cruizlib.interop.dependencygraph import dependencygraph_from_node_dependees
 
 try:
@@ -458,24 +458,24 @@ class RecipeWidget(QtWidgets.QMainWindow):
                 values.append((key, value, None))
         return values
 
-    # TODO: why does this have to be PurePosixPath? to create such a path,
+    # TODO: why does this have to be PurePath? to create such a path,
     # it cannot be pure
     def get_working_dir(
         self,
         workflow_cwd: WorkflowCwd,
         common_subdir: typing.Optional[str],
-    ) -> pathlib.PurePosixPath:
+    ) -> pathlib.PurePath:
         """Get the working directory for the recipe."""
         if common_subdir is not None:
             common_subdir_path = pathlib.Path(common_subdir)
             if common_subdir_path.is_absolute():
-                return pathlib.PurePosixPath(common_subdir_path)
+                return pathlib.PurePath(common_subdir_path)
         if workflow_cwd == WorkflowCwd.RELATIVE_TO_RECIPE:
-            cwd = pathlib.PurePosixPath(self.recipe.folder)
+            cwd = pathlib.PurePath(self.recipe.folder)
         elif workflow_cwd == WorkflowCwd.RELATIVE_TO_GIT:
             assert self._git_repository
             assert self._git_repository.working_tree_dir
-            cwd = pathlib.PurePosixPath(self._git_repository.working_tree_dir)
+            cwd = pathlib.PurePath(self._git_repository.working_tree_dir)
         if common_subdir is not None:
             cwd /= common_subdir
         return cwd

--- a/src/cruiz/recipe/toolbars/command.py
+++ b/src/cruiz/recipe/toolbars/command.py
@@ -12,7 +12,6 @@ import cruiz.globals
 import cruiz.workers.api as workers_api
 from cruiz.environ import EnvironSaver
 from cruiz.exceptions import RecipeInspectionError
-from cruiz.interop.commandparameters import CommandParameters
 from cruiz.settings.managers.compilercachepreferences import CompilerCacheSettingsReader
 from cruiz.settings.managers.generalpreferences import GeneralSettingsReader
 from cruiz.settings.managers.recipe import RecipeSettings, RecipeSettingsReader
@@ -20,6 +19,7 @@ from cruiz.settings.managers.shortcuts import ShortcutSettingsReader
 
 import cruizlib.globals
 from cruizlib.constants import BuildFeatureConstants, CompilerCacheTypes
+from cruizlib.interop.commandparameters import CommandParameters
 
 IS_CONAN_V1 = cruizlib.globals.CONAN_MAJOR_VERSION == 1
 

--- a/src/cruiz/workers/api/v1/arbitrary.py
+++ b/src/cruiz/workers/api/v1/arbitrary.py
@@ -13,7 +13,7 @@ from . import worker
 if typing.TYPE_CHECKING:
     import multiprocessing
 
-    from cruiz.interop.commandparameters import CommandParameters
+    from cruizlib.interop.commandparameters import CommandParameters
 
 
 def invoke(queue: multiprocessing.Queue[Message], params: CommandParameters) -> None:

--- a/src/cruiz/workers/api/v1/build.py
+++ b/src/cruiz/workers/api/v1/build.py
@@ -13,7 +13,7 @@ from . import worker
 if typing.TYPE_CHECKING:
     import multiprocessing
 
-    from cruiz.interop.commandparameters import CommandParameters
+    from cruizlib.interop.commandparameters import CommandParameters
 
 
 def invoke(queue: multiprocessing.Queue[Message], params: CommandParameters) -> None:

--- a/src/cruiz/workers/api/v1/cmakebuildtool.py
+++ b/src/cruiz/workers/api/v1/cmakebuildtool.py
@@ -13,7 +13,7 @@ from cruiz.workers.utils.worker import Worker
 from cruizlib.interop.message import Message, Stderr, Stdout, Success
 
 if typing.TYPE_CHECKING:
-    from cruiz.interop.commandparameters import CommandParameters
+    from cruizlib.interop.commandparameters import CommandParameters
 
 
 def invoke(queue: multiprocessing.Queue[Message], params: CommandParameters) -> None:

--- a/src/cruiz/workers/api/v1/conanapi.py
+++ b/src/cruiz/workers/api/v1/conanapi.py
@@ -17,9 +17,9 @@ _do_monkey_patching()
 from conans.client import conan_api, output, runner  # noqa: E402, I100
 from conans.paths import get_conan_user_home  # noqa: E402
 
-from cruiz.interop.commandparameters import CommandParameters  # noqa: E402
 from cruiz.workers.utils.stream import QueuedStreamSix  # noqa: E402
 
+from cruizlib.interop.commandparameters import CommandParameters  # noqa: E402
 from cruizlib.interop.commonparameters import CommonParameters  # noqa: E402
 from cruizlib.interop.message import Message, Stderr, Stdout  # noqa: E402
 
@@ -44,9 +44,8 @@ def instance(
         print_commands_to_output = cache.config.print_commands_to_output
         if params.cwd:
             # TODO: this has some broken assumptions about pure paths
-            if isinstance(params.cwd, pathlib.PurePosixPath):
-                path = pathlib.Path(params.cwd)
-                path.mkdir(parents=True, exist_ok=True)
+            if isinstance(params.cwd, pathlib.PurePath):
+                pathlib.Path(params.cwd).mkdir(parents=True, exist_ok=True)
             else:
                 params.cwd.mkdir(parents=True, exist_ok=True)
             os.chdir(params.cwd)

--- a/src/cruiz/workers/api/v1/configinstall.py
+++ b/src/cruiz/workers/api/v1/configinstall.py
@@ -14,7 +14,7 @@ from . import worker
 if typing.TYPE_CHECKING:
     import multiprocessing
 
-    from cruiz.interop.commandparameters import CommandParameters
+    from cruizlib.interop.commandparameters import CommandParameters
 
 
 def invoke(queue: multiprocessing.Queue[Message], params: CommandParameters) -> None:

--- a/src/cruiz/workers/api/v1/create.py
+++ b/src/cruiz/workers/api/v1/create.py
@@ -15,7 +15,7 @@ from . import worker
 if typing.TYPE_CHECKING:
     import multiprocessing
 
-    from cruiz.interop.commandparameters import CommandParameters
+    from cruizlib.interop.commandparameters import CommandParameters
 
 
 def invoke(queue: multiprocessing.Queue[Message], params: CommandParameters) -> None:

--- a/src/cruiz/workers/api/v1/deletecmakecache.py
+++ b/src/cruiz/workers/api/v1/deletecmakecache.py
@@ -14,7 +14,7 @@ from cruizlib.interop.message import Message, Stdout, Success
 if typing.TYPE_CHECKING:
     import multiprocessing
 
-    from cruiz.interop.commandparameters import CommandParameters
+    from cruizlib.interop.commandparameters import CommandParameters
 
 
 def invoke(queue: multiprocessing.Queue[Message], params: CommandParameters) -> None:

--- a/src/cruiz/workers/api/v1/exportpackage.py
+++ b/src/cruiz/workers/api/v1/exportpackage.py
@@ -13,7 +13,7 @@ from . import worker
 if typing.TYPE_CHECKING:
     import multiprocessing
 
-    from cruiz.interop.commandparameters import CommandParameters
+    from cruizlib.interop.commandparameters import CommandParameters
 
 
 def invoke(queue: multiprocessing.Queue[Message], params: CommandParameters) -> None:

--- a/src/cruiz/workers/api/v1/imports.py
+++ b/src/cruiz/workers/api/v1/imports.py
@@ -13,7 +13,7 @@ from . import worker
 if typing.TYPE_CHECKING:
     import multiprocessing
 
-    from cruiz.interop.commandparameters import CommandParameters
+    from cruizlib.interop.commandparameters import CommandParameters
 
 
 def invoke(queue: multiprocessing.Queue[Message], params: CommandParameters) -> None:

--- a/src/cruiz/workers/api/v1/install.py
+++ b/src/cruiz/workers/api/v1/install.py
@@ -15,7 +15,7 @@ from . import worker
 if typing.TYPE_CHECKING:
     import multiprocessing
 
-    from cruiz.interop.commandparameters import CommandParameters
+    from cruizlib.interop.commandparameters import CommandParameters
 
 
 def invoke(queue: multiprocessing.Queue[Message], params: CommandParameters) -> None:

--- a/src/cruiz/workers/api/v1/lockcreate.py
+++ b/src/cruiz/workers/api/v1/lockcreate.py
@@ -17,7 +17,7 @@ from . import worker
 if typing.TYPE_CHECKING:
     import multiprocessing
 
-    from cruiz.interop.commandparameters import CommandParameters
+    from cruizlib.interop.commandparameters import CommandParameters
 
 
 def invoke(queue: multiprocessing.Queue[Message], params: CommandParameters) -> None:

--- a/src/cruiz/workers/api/v1/meta.py
+++ b/src/cruiz/workers/api/v1/meta.py
@@ -18,7 +18,7 @@ from cruizlib.interop.pod import ConanHook, ConanRemote
 from . import worker
 
 if typing.TYPE_CHECKING:
-    from cruiz.interop.commandparameters import CommandParameters
+    from cruizlib.interop.commandparameters import CommandParameters
 
 
 def _remotes_list(api: typing.Any) -> typing.List[ConanRemote]:

--- a/src/cruiz/workers/api/v1/package.py
+++ b/src/cruiz/workers/api/v1/package.py
@@ -13,7 +13,7 @@ from . import worker
 if typing.TYPE_CHECKING:
     import multiprocessing
 
-    from cruiz.interop.commandparameters import CommandParameters
+    from cruizlib.interop.commandparameters import CommandParameters
 
 
 def invoke(queue: multiprocessing.Queue[Message], params: CommandParameters) -> None:

--- a/src/cruiz/workers/api/v1/removeallpackages.py
+++ b/src/cruiz/workers/api/v1/removeallpackages.py
@@ -13,7 +13,7 @@ from . import worker
 if typing.TYPE_CHECKING:
     import multiprocessing
 
-    from cruiz.interop.commandparameters import CommandParameters
+    from cruizlib.interop.commandparameters import CommandParameters
 
 
 def invoke(queue: multiprocessing.Queue[Message], params: CommandParameters) -> None:

--- a/src/cruiz/workers/api/v1/removelocks.py
+++ b/src/cruiz/workers/api/v1/removelocks.py
@@ -13,7 +13,7 @@ from . import worker
 if typing.TYPE_CHECKING:
     import multiprocessing
 
-    from cruiz.interop.commandparameters import CommandParameters
+    from cruizlib.interop.commandparameters import CommandParameters
 
 
 def invoke(queue: multiprocessing.Queue[Message], params: CommandParameters) -> None:

--- a/src/cruiz/workers/api/v1/removepackage.py
+++ b/src/cruiz/workers/api/v1/removepackage.py
@@ -13,7 +13,7 @@ from . import worker
 if typing.TYPE_CHECKING:
     import multiprocessing
 
-    from cruiz.interop.commandparameters import CommandParameters
+    from cruizlib.interop.commandparameters import CommandParameters
 
 
 def invoke(queue: multiprocessing.Queue[Message], params: CommandParameters) -> None:

--- a/src/cruiz/workers/api/v1/source.py
+++ b/src/cruiz/workers/api/v1/source.py
@@ -13,7 +13,7 @@ from . import worker
 if typing.TYPE_CHECKING:
     import multiprocessing
 
-    from cruiz.interop.commandparameters import CommandParameters
+    from cruizlib.interop.commandparameters import CommandParameters
 
 
 def invoke(queue: multiprocessing.Queue[Message], params: CommandParameters) -> None:

--- a/src/cruiz/workers/api/v1/testpackage.py
+++ b/src/cruiz/workers/api/v1/testpackage.py
@@ -15,7 +15,7 @@ from . import worker
 if typing.TYPE_CHECKING:
     import multiprocessing
 
-    from cruiz.interop.commandparameters import CommandParameters
+    from cruizlib.interop.commandparameters import CommandParameters
 
 
 def invoke(queue: multiprocessing.Queue[Message], params: CommandParameters) -> None:

--- a/src/cruiz/workers/api/v2/arbitrary.py
+++ b/src/cruiz/workers/api/v2/arbitrary.py
@@ -16,7 +16,7 @@ from cruizlib.interop.message import Failure, Message, Success
 from . import worker
 
 if typing.TYPE_CHECKING:
-    from cruiz.interop.commandparameters import CommandParameters
+    from cruizlib.interop.commandparameters import CommandParameters
 
 
 def invoke(queue: multiprocessing.Queue[Message], params: CommandParameters) -> None:

--- a/src/cruiz/workers/api/v2/build.py
+++ b/src/cruiz/workers/api/v2/build.py
@@ -12,7 +12,7 @@ from cruizlib.interop.message import Message, Success
 from . import worker
 
 if typing.TYPE_CHECKING:
-    from cruiz.interop.commandparameters import CommandParameters
+    from cruizlib.interop.commandparameters import CommandParameters
 
 
 def invoke(queue: multiprocessing.Queue[Message], params: CommandParameters) -> None:

--- a/src/cruiz/workers/api/v2/configinstall.py
+++ b/src/cruiz/workers/api/v2/configinstall.py
@@ -14,7 +14,7 @@ from . import worker
 if typing.TYPE_CHECKING:
     import multiprocessing
 
-    from cruiz.interop.commandparameters import CommandParameters
+    from cruizlib.interop.commandparameters import CommandParameters
 
 
 def invoke(queue: multiprocessing.Queue[Message], params: CommandParameters) -> None:

--- a/src/cruiz/workers/api/v2/create.py
+++ b/src/cruiz/workers/api/v2/create.py
@@ -12,7 +12,7 @@ from cruizlib.interop.message import Message, Success
 from . import worker
 
 if typing.TYPE_CHECKING:
-    from cruiz.interop.commandparameters import CommandParameters
+    from cruizlib.interop.commandparameters import CommandParameters
 
 
 def invoke(queue: multiprocessing.Queue[Message], params: CommandParameters) -> None:

--- a/src/cruiz/workers/api/v2/exportpackage.py
+++ b/src/cruiz/workers/api/v2/exportpackage.py
@@ -12,7 +12,7 @@ from cruizlib.interop.message import Message, Success
 from . import worker
 
 if typing.TYPE_CHECKING:
-    from cruiz.interop.commandparameters import CommandParameters
+    from cruizlib.interop.commandparameters import CommandParameters
 
 
 def invoke(queue: multiprocessing.Queue[Message], params: CommandParameters) -> None:

--- a/src/cruiz/workers/api/v2/install.py
+++ b/src/cruiz/workers/api/v2/install.py
@@ -12,7 +12,7 @@ from cruizlib.interop.message import Message, Success
 from . import worker
 
 if typing.TYPE_CHECKING:
-    from cruiz.interop.commandparameters import CommandParameters
+    from cruizlib.interop.commandparameters import CommandParameters
 
 
 def invoke(queue: multiprocessing.Queue[Message], params: CommandParameters) -> None:

--- a/src/cruiz/workers/api/v2/lockcreate.py
+++ b/src/cruiz/workers/api/v2/lockcreate.py
@@ -16,7 +16,7 @@ from cruizlib.interop.packagenode import PackageNode
 from . import worker
 
 if typing.TYPE_CHECKING:
-    from cruiz.interop.commandparameters import CommandParameters
+    from cruizlib.interop.commandparameters import CommandParameters
 
 
 def invoke(queue: multiprocessing.Queue[Message], params: CommandParameters) -> None:

--- a/src/cruiz/workers/api/v2/meta.py
+++ b/src/cruiz/workers/api/v2/meta.py
@@ -20,7 +20,7 @@ from cruizlib.interop.pod import ConanHook, ConanRemote
 from . import worker
 
 if typing.TYPE_CHECKING:
-    from cruiz.interop.commandparameters import CommandParameters
+    from cruizlib.interop.commandparameters import CommandParameters
 
 
 def _interop_remote_list(api: typing.Any) -> typing.List[ConanRemote]:

--- a/src/cruiz/workers/api/v2/removeallpackages.py
+++ b/src/cruiz/workers/api/v2/removeallpackages.py
@@ -13,7 +13,7 @@ from . import worker
 if typing.TYPE_CHECKING:
     import multiprocessing
 
-    from cruiz.interop.commandparameters import CommandParameters
+    from cruizlib.interop.commandparameters import CommandParameters
 
 
 def invoke(queue: multiprocessing.Queue[Message], params: CommandParameters) -> None:

--- a/src/cruiz/workers/api/v2/removepackage.py
+++ b/src/cruiz/workers/api/v2/removepackage.py
@@ -13,7 +13,7 @@ from . import worker
 if typing.TYPE_CHECKING:
     import multiprocessing
 
-    from cruiz.interop.commandparameters import CommandParameters
+    from cruizlib.interop.commandparameters import CommandParameters
 
 
 def invoke(queue: multiprocessing.Queue[Message], params: CommandParameters) -> None:

--- a/src/cruiz/workers/api/v2/source.py
+++ b/src/cruiz/workers/api/v2/source.py
@@ -13,7 +13,7 @@ from cruizlib.interop.message import Message, Success
 from . import worker
 
 if typing.TYPE_CHECKING:
-    from cruiz.interop.commandparameters import CommandParameters
+    from cruizlib.interop.commandparameters import CommandParameters
 
 
 def invoke(queue: multiprocessing.Queue[Message], params: CommandParameters) -> None:

--- a/src/cruiz/workers/api/v2/testpackage.py
+++ b/src/cruiz/workers/api/v2/testpackage.py
@@ -12,7 +12,7 @@ from cruizlib.interop.message import Message, Success
 from . import worker
 
 if typing.TYPE_CHECKING:
-    from cruiz.interop.commandparameters import CommandParameters
+    from cruizlib.interop.commandparameters import CommandParameters
 
 
 def invoke(queue: multiprocessing.Queue[Message], params: CommandParameters) -> None:

--- a/src/cruiz/workers/utils/worker.py
+++ b/src/cruiz/workers/utils/worker.py
@@ -13,10 +13,10 @@ import typing
 
 from PySide6 import QtCore
 
-from cruiz.interop.commandparameters import CommandParameters
 from cruiz.workers.utils.env import clear_conan_env, set_env
 from cruiz.workers.utils.text2html import text_to_html
 
+from cruizlib.interop.commandparameters import CommandParameters
 from cruizlib.interop.commonparameters import CommonParameters
 from cruizlib.interop.message import Failure, Message, Stdout
 

--- a/src/cruizlib/interop/commandparameters.py
+++ b/src/cruizlib/interop/commandparameters.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+# pylint: disable=fixme
 """Conan command parameters."""
 
 from __future__ import annotations
@@ -9,7 +10,8 @@ import typing
 from io import StringIO
 
 import cruizlib.globals
-from cruizlib.interop.commonparameters import CommonParameters
+
+from .commonparameters import CommonParameters
 
 if typing.TYPE_CHECKING:
     from cruizlib.constants import BuildFeatureConstants
@@ -17,6 +19,7 @@ if typing.TYPE_CHECKING:
 
 # TODO: should a recipe be in here? it is quite a heavyweight Context object though
 class CommandParameters(CommonParameters):
+    # pylint: disable=too-many-instance-attributes, too-many-public-methods
     """Representation of all the arguments to a command."""
 
     def __init__(
@@ -30,18 +33,18 @@ class CommandParameters(CommonParameters):
         """Initialise a CommandParameters."""
         super().__init__(worker)
         self.verb = verb
-        self._recipe_path: typing.Optional[pathlib.Path] = (
+        self._recipe_path: typing.Optional[pathlib.PurePath] = (
             None  # TODO: aliased with the recipe, so should we store it?
         )
-        self._cwd: typing.Optional[pathlib.Path] = None
+        self._cwd: typing.Optional[pathlib.PurePath] = None
         self._profile: typing.Optional[str] = None
-        self._common_subdir: typing.Optional[pathlib.PurePosixPath] = None
-        self._install_folder: typing.Optional[pathlib.PurePosixPath] = None
-        self._imports_folder: typing.Optional[pathlib.PurePosixPath] = None
-        self._source_folder: typing.Optional[pathlib.PurePosixPath] = None
-        self._build_folder: typing.Optional[pathlib.PurePosixPath] = None
-        self._package_folder: typing.Optional[pathlib.PurePosixPath] = None
-        self._test_build_folder: typing.Optional[pathlib.PurePosixPath] = None
+        self._common_subdir: typing.Optional[pathlib.PurePath] = None
+        self._install_folder: typing.Optional[pathlib.PurePath] = None
+        self._imports_folder: typing.Optional[pathlib.PurePath] = None
+        self._source_folder: typing.Optional[pathlib.PurePath] = None
+        self._build_folder: typing.Optional[pathlib.PurePath] = None
+        self._package_folder: typing.Optional[pathlib.PurePath] = None
+        self._test_build_folder: typing.Optional[pathlib.PurePath] = None
         self._name: typing.Optional[str] = None
         self._version: typing.Optional[str] = (
             None  # TODO: these are aliased with the recipe, so should we store it?
@@ -55,17 +58,18 @@ class CommandParameters(CommonParameters):
         self._named_args: typing.Dict[str, str] = {}
         self._time_commands: typing.Optional[bool] = None
         self._v2_omit_test_folder: typing.Optional[bool] = None
-        self._v2_needs_reference: typing.Optional[bool] = None
+        self._v2_need_reference: typing.Optional[bool] = None
         self._extra_options: typing.Optional[str] = None
 
     def to_args(self) -> typing.List[str]:
+        # pylint: disable=too-many-branches
         """Get the argument list corresponding to these command parameters."""
         components = [self.verb]
-        if self._profile:
+        if self.profile:
             components.extend(
                 [
                     "-pr",
-                    self._profile,
+                    self.profile,
                 ]
             )
         if self._args:
@@ -82,37 +86,37 @@ class CommandParameters(CommonParameters):
                         f"{name}/*:{option_name}={value}",
                     ]
                 )
-            if not self._v2_needs_reference:
-                if self._name:
-                    components.extend(["--name", self._name])
-                if self._version:
-                    components.extend(["--version", self._version])
-                if self._user:
-                    components.extend(["--user", self._user])
-                if self._channel:
-                    components.extend(["--channel", self._channel])
+            if not self.v2_need_reference:
+                if self.name:
+                    components.extend(["--name", self.name])
+                if self.version:
+                    components.extend(["--version", self.version])
+                if self.user:
+                    components.extend(["--user", self.user])
+                if self.channel:
+                    components.extend(["--channel", self.channel])
             if self.v2_omit_test_folder:
                 components.extend(["-tf", ""])
-            if self._force:
+            if self.force:
                 components.append("-c")
             # no named args
-            if self._recipe_path:
-                components.append(str(self._recipe_path))
-            if self._v2_needs_reference and self._package_reference:
-                components.append(self._package_reference)
+            if self.recipe_path:
+                components.append(str(self.recipe_path))
+            if self.v2_need_reference and self.package_reference:
+                components.append(self.package_reference)
         elif cruizlib.globals.CONAN_MAJOR_VERSION == 1:
-            if self._install_folder:
-                components.extend(["-if", str(self._install_folder)])
-            if self._imports_folder:
-                components.extend(["-imf", str(self._imports_folder)])
-            if self._source_folder:
-                components.extend(["-sf", str(self._source_folder)])
-            if self._build_folder:
-                components.extend(["-bf", str(self._build_folder)])
-            if self._package_folder:
-                components.extend(["-pf", str(self._package_folder)])
-            if self._test_build_folder:
-                components.extend(["-tbf", str(self._test_build_folder)])
+            if self.install_folder:
+                components.extend(["-if", str(self.install_folder)])
+            if self.imports_folder:
+                components.extend(["-imf", str(self.imports_folder)])
+            if self.source_folder:
+                components.extend(["-sf", str(self.source_folder)])
+            if self.build_folder:
+                components.extend(["-bf", str(self.build_folder)])
+            if self.package_folder:
+                components.extend(["-pf", str(self.package_folder)])
+            if self.test_build_folder:
+                components.extend(["-tbf", str(self.test_build_folder)])
             for key, value in self._options.items():
                 components.extend(
                     [
@@ -120,13 +124,13 @@ class CommandParameters(CommonParameters):
                         f"{key}={value}",
                     ]
                 )
-            if self._force:
+            if self.force:
                 components.append("-f")
             # no named args
-            if self._recipe_path:
-                components.append(str(self._recipe_path))
-            if self._package_reference:
-                components.append(self._package_reference)
+            if self.recipe_path:
+                components.append(str(self.recipe_path))
+            if self.package_reference:
+                components.append(self.package_reference)
         return components
 
     def __str__(self) -> str:
@@ -212,7 +216,7 @@ class CommandParameters(CommonParameters):
         return expression
 
     @property
-    def recipe_path(self) -> typing.Optional[pathlib.Path]:
+    def recipe_path(self) -> typing.Optional[pathlib.PurePath]:
         """
         Get the path of the recipe used in this command.
 
@@ -221,11 +225,11 @@ class CommandParameters(CommonParameters):
         return self._recipe_path
 
     @recipe_path.setter
-    def recipe_path(self, value: typing.Optional[pathlib.Path]) -> None:
+    def recipe_path(self, value: typing.Optional[pathlib.PurePath]) -> None:
         self._recipe_path = value
 
     @property
-    def cwd(self) -> typing.Optional[pathlib.Path]:
+    def cwd(self) -> typing.Optional[pathlib.PurePath]:
         """
         Get the current directory used in this command.
 
@@ -234,7 +238,7 @@ class CommandParameters(CommonParameters):
         return self._cwd
 
     @cwd.setter
-    def cwd(self, value: pathlib.Path) -> None:
+    def cwd(self, value: pathlib.PurePath) -> None:
         self._cwd = value
 
     @property
@@ -252,7 +256,7 @@ class CommandParameters(CommonParameters):
         self._profile = value
 
     @property
-    def common_subdir(self) -> typing.Optional[pathlib.PurePosixPath]:
+    def common_subdir(self) -> typing.Optional[pathlib.PurePath]:
         """
         Get the common subdirectory to apply atop of the current working directory.
 
@@ -261,11 +265,11 @@ class CommandParameters(CommonParameters):
         return self._common_subdir
 
     @common_subdir.setter
-    def common_subdir(self, value: typing.Optional[pathlib.PurePosixPath]) -> None:
+    def common_subdir(self, value: typing.Optional[pathlib.PurePath]) -> None:
         self._common_subdir = value
 
     @property
-    def install_folder(self) -> typing.Optional[pathlib.PurePosixPath]:
+    def install_folder(self) -> typing.Optional[pathlib.PurePath]:
         """
         Get the install folder to use in the command against this recipe.
 
@@ -275,11 +279,11 @@ class CommandParameters(CommonParameters):
         return self._install_folder
 
     @install_folder.setter
-    def install_folder(self, value: typing.Optional[pathlib.PurePosixPath]) -> None:
+    def install_folder(self, value: typing.Optional[pathlib.PurePath]) -> None:
         self._install_folder = value
 
     @property
-    def imports_folder(self) -> typing.Optional[pathlib.PurePosixPath]:
+    def imports_folder(self) -> typing.Optional[pathlib.PurePath]:
         """
         Get the imports folder to use in the command against this recipe.
 
@@ -289,11 +293,11 @@ class CommandParameters(CommonParameters):
         return self._imports_folder
 
     @imports_folder.setter
-    def imports_folder(self, value: typing.Optional[pathlib.PurePosixPath]) -> None:
+    def imports_folder(self, value: typing.Optional[pathlib.PurePath]) -> None:
         self._imports_folder = value
 
     @property
-    def source_folder(self) -> typing.Optional[pathlib.PurePosixPath]:
+    def source_folder(self) -> typing.Optional[pathlib.PurePath]:
         """
         Get the source folder to use in the command against this recipe.
 
@@ -303,11 +307,11 @@ class CommandParameters(CommonParameters):
         return self._source_folder
 
     @source_folder.setter
-    def source_folder(self, value: typing.Optional[pathlib.PurePosixPath]) -> None:
+    def source_folder(self, value: typing.Optional[pathlib.PurePath]) -> None:
         self._source_folder = value
 
     @property
-    def build_folder(self) -> typing.Optional[pathlib.PurePosixPath]:
+    def build_folder(self) -> typing.Optional[pathlib.PurePath]:
         """
         Get the build folder to use in the command against this recipe.
 
@@ -317,11 +321,11 @@ class CommandParameters(CommonParameters):
         return self._build_folder
 
     @build_folder.setter
-    def build_folder(self, value: typing.Optional[pathlib.PurePosixPath]) -> None:
+    def build_folder(self, value: typing.Optional[pathlib.PurePath]) -> None:
         self._build_folder = value
 
     @property
-    def package_folder(self) -> typing.Optional[pathlib.PurePosixPath]:
+    def package_folder(self) -> typing.Optional[pathlib.PurePath]:
         """
         Get the package folder to use in the command against this recipe.
 
@@ -331,11 +335,11 @@ class CommandParameters(CommonParameters):
         return self._package_folder
 
     @package_folder.setter
-    def package_folder(self, value: typing.Optional[pathlib.PurePosixPath]) -> None:
+    def package_folder(self, value: typing.Optional[pathlib.PurePath]) -> None:
         self._package_folder = value
 
     @property
-    def test_build_folder(self) -> typing.Optional[pathlib.PurePosixPath]:
+    def test_build_folder(self) -> typing.Optional[pathlib.PurePath]:
         """
         Get the test build folder to use in the command against this recipe.
 
@@ -345,7 +349,7 @@ class CommandParameters(CommonParameters):
         return self._test_build_folder
 
     @test_build_folder.setter
-    def test_build_folder(self, value: typing.Optional[pathlib.PurePosixPath]) -> None:
+    def test_build_folder(self, value: typing.Optional[pathlib.PurePath]) -> None:
         self._test_build_folder = value
 
     @property
@@ -442,16 +446,20 @@ class CommandParameters(CommonParameters):
         return self._package_reference
 
     def make_package_reference(self) -> None:
-        """Make the package reference given name, version, user and channel already set."""  # noqa: E501
+        """
+        Make a Conan package reference.
+
+        Uses the name, version, user and channel already set.
+        """
         package_reference = StringIO()
-        if self._name:
-            package_reference.write(f"{self._name}/")
-        if self._version:
-            package_reference.write(f"{self._version}@")
-        if self._user:
-            package_reference.write(self._user)
-        if self._channel:
-            package_reference.write(f"/{self._channel}")
+        if self.name:
+            package_reference.write(f"{self.name}/")
+        if self.version:
+            package_reference.write(f"{self.version}@")
+        if self.user:
+            package_reference.write(self.user)
+        if self.channel:
+            package_reference.write(f"/{self.channel}")
         # in some cases, this can be empty (e.g. export-pkg)
         # but not in others (e.g. test)
         self._package_reference = package_reference.getvalue()
@@ -499,11 +507,11 @@ class CommandParameters(CommonParameters):
     @property
     def v2_need_reference(self) -> typing.Optional[bool]:
         """Whether a package reference is actually needed in Conan v2+."""
-        return self._v2_needs_reference
+        return self._v2_need_reference
 
     @v2_need_reference.setter
     def v2_need_reference(self, value: typing.Optional[bool]) -> None:
-        self._v2_needs_reference = value
+        self._v2_need_reference = value
 
     @property
     def extra_options(self) -> typing.Optional[str]:

--- a/tests/interop/test_commandparameters.py
+++ b/tests/interop/test_commandparameters.py
@@ -1,0 +1,273 @@
+"""Tests for command parameters."""
+
+import os
+import pathlib
+import typing
+
+import cruizlib.globals
+from cruizlib.constants import BuildFeatureConstants
+from cruizlib.interop.commandparameters import CommandParameters
+
+
+MOCKED_VERB = "mocked_verb"
+
+
+def _mocked_worker(first: typing.Any, second: typing.Any) -> None:
+    pass
+
+
+def test_cmdparams_profile() -> None:
+    """Set the Conan profile."""
+    cp = CommandParameters(MOCKED_VERB, _mocked_worker)
+    cp.profile = "my_profile"
+    assert cp.to_args()[-2] == "-pr"
+    assert cp.to_args()[-1] == "my_profile"
+
+
+def test_cmdparams_custom_args() -> None:
+    """Add custom arguments."""
+    cp = CommandParameters(MOCKED_VERB, _mocked_worker)
+    args = cp.arguments
+    args.append("--update")
+    assert cp.to_args()[-1] == "--update"
+
+
+def test_cmdparams_install_folder(tmp_path: pathlib.Path) -> None:
+    """Set the Conan install folder."""
+    cp = CommandParameters(MOCKED_VERB, _mocked_worker)
+    cp.install_folder = tmp_path
+    if cruizlib.globals.CONAN_MAJOR_VERSION == 1:
+        assert cp.to_args()[-2] == "-if"
+        assert cp.to_args()[-1] == os.fspath(tmp_path)
+    else:
+        assert len(cp.to_args()) == 1
+
+
+def test_cmdparams_imports_folder(tmp_path: pathlib.Path) -> None:
+    """Set the Conan imports folder."""
+    cp = CommandParameters(MOCKED_VERB, _mocked_worker)
+    cp.imports_folder = tmp_path
+    if cruizlib.globals.CONAN_MAJOR_VERSION == 1:
+        assert cp.to_args()[-2] == "-imf"
+        assert cp.to_args()[-1] == os.fspath(tmp_path)
+    else:
+        assert len(cp.to_args()) == 1
+
+
+def test_cmdparams_source_folder(tmp_path: pathlib.Path) -> None:
+    """Set the Conan source folder."""
+    cp = CommandParameters(MOCKED_VERB, _mocked_worker)
+    cp.source_folder = tmp_path
+    if cruizlib.globals.CONAN_MAJOR_VERSION == 1:
+        assert cp.to_args()[-2] == "-sf"
+        assert cp.to_args()[-1] == os.fspath(tmp_path)
+    else:
+        assert len(cp.to_args()) == 1
+
+
+def test_cmdparams_build_folder(tmp_path: pathlib.Path) -> None:
+    """Set the Conan build folder."""
+    cp = CommandParameters(MOCKED_VERB, _mocked_worker)
+    cp.build_folder = tmp_path
+    if cruizlib.globals.CONAN_MAJOR_VERSION == 1:
+        assert cp.to_args()[-2] == "-bf"
+        assert cp.to_args()[-1] == os.fspath(tmp_path)
+    else:
+        assert len(cp.to_args()) == 1
+
+
+def test_cmdparams_package_folder(tmp_path: pathlib.Path) -> None:
+    """Set the Conan package folder."""
+    cp = CommandParameters(MOCKED_VERB, _mocked_worker)
+    cp.package_folder = tmp_path
+    if cruizlib.globals.CONAN_MAJOR_VERSION == 1:
+        assert cp.to_args()[-2] == "-pf"
+        assert cp.to_args()[-1] == os.fspath(tmp_path)
+    else:
+        assert len(cp.to_args()) == 1
+
+
+def test_cmdparams_test_folder(tmp_path: pathlib.Path) -> None:
+    """Set the Conan test folder."""
+    cp = CommandParameters(MOCKED_VERB, _mocked_worker)
+    cp.test_build_folder = tmp_path
+    if cruizlib.globals.CONAN_MAJOR_VERSION == 1:
+        assert cp.to_args()[-2] == "-tbf"
+        assert cp.to_args()[-1] == os.fspath(tmp_path)
+    else:
+        assert len(cp.to_args()) == 1
+
+
+def test_cmdparams_options() -> None:
+    """Set the Conan recipe options."""
+    cp = CommandParameters(MOCKED_VERB, _mocked_worker)
+    if cruizlib.globals.CONAN_MAJOR_VERSION == 1:
+        cp.add_option(None, "global_option", "go_value")
+        cp.add_option("my_package", "package_option", "po_value")
+        assert len(cp.options) == 2
+        assert cp.to_args()[-2] == "-o"
+        assert cp.to_args()[-1] == "my_package:package_option=po_value"
+        assert cp.to_args()[-4] == "-o"
+        assert cp.to_args()[-3] == "global_option=go_value"
+    else:
+        # options always have a package prefix now
+        cp.add_option("my_package", "package_option", "po_value")
+        assert len(cp.options) == 1
+        assert cp.to_args()[-2] == "-o"
+        assert cp.to_args()[-1] == "my_package/*:package_option=po_value"
+
+
+def test_cmdparams_force() -> None:
+    """Set the Conan force option."""
+    cp = CommandParameters(MOCKED_VERB, _mocked_worker)
+    cp.force = True
+    if cruizlib.globals.CONAN_MAJOR_VERSION == 1:
+        assert cp.to_args()[-1] == "-f"
+    else:
+        assert cp.to_args()[-1] == "-c"
+
+
+def test_cmdparams_recipe_path(tmp_path: pathlib.Path) -> None:
+    """Set the Conan recipe path."""
+    cp = CommandParameters(MOCKED_VERB, _mocked_worker)
+    cp.recipe_path = tmp_path
+    assert cp.to_args()[-1] == os.fspath(tmp_path)
+
+
+def test_cmdparams_package_reference() -> None:
+    """Set the Conan package_reference."""
+    cp = CommandParameters(MOCKED_VERB, _mocked_worker)
+    cp.name = "my_package"
+    cp.version = "1.2.3"
+    cp.user = "user"
+    cp.channel = "channel"
+    cp.make_package_reference()
+    if cruizlib.globals.CONAN_MAJOR_VERSION == 1:
+        assert cp.to_args()[-1] == "my_package/1.2.3@user/channel"
+    else:
+        cp.v2_need_reference = True
+        assert cp.to_args()[-1] == "my_package/1.2.3@user/channel"
+        cp.v2_need_reference = False
+        assert cp.to_args()[-8] == "--name"
+        assert cp.to_args()[-7] == "my_package"
+        assert cp.to_args()[-6] == "--version"
+        assert cp.to_args()[-5] == "1.2.3"
+        assert cp.to_args()[-4] == "--user"
+        assert cp.to_args()[-3] == "user"
+        assert cp.to_args()[-2] == "--channel"
+        assert cp.to_args()[-1] == "channel"
+
+
+def test_cmdparams_cmd_expression(tmp_path: pathlib.Path) -> None:
+    """Expressions available in CMD evaluation."""
+    cp = CommandParameters(MOCKED_VERB, _mocked_worker)
+    cp.set_build_feature(BuildFeatureConstants.CMAKEFINDDEBUGMODE, "ON")
+    cp.added_environment.update({"MY_ENVVAR": "ENVVAR_VALUE", "CONAN_COLOR_DARK": "1"})
+    cp.removed_environment.append("MY_REMOVED_ENVVAR")
+    cp.cwd = tmp_path
+    cp.arguments.append("")  # intentionally empty
+    cp.add_option("*", "shared", "True")
+    expr = cp.cmd_expression.getvalue()
+    assert "rem BuildFeatureConstants.CMAKEFINDDEBUGMODE=ON" in expr
+    assert "set MY_ENVVAR=ENVVAR_VALUE &&" in expr
+    assert "rem CONAN_COLOR_DARK=1" in expr
+    assert f"cd {tmp_path} &&" in expr
+    assert "set MY_REMOVED_ENVVAR= &&" in expr
+    assert '""' in expr
+    if cruizlib.globals.CONAN_MAJOR_VERSION == 1:
+        assert '-o "*:shared=True"' in expr
+    else:
+        assert '-o "*/*:shared=True"' in expr
+
+
+def test_cmdparams_bash_expression(tmp_path: pathlib.Path) -> None:
+    """Expressions available in bash evaluation."""
+    cp = CommandParameters(MOCKED_VERB, _mocked_worker)
+    cp.set_build_feature(BuildFeatureConstants.CMAKEFINDDEBUGMODE, "ON")
+    cp.added_environment.update({"MY_ENVVAR": "ENVVAR_VALUE", "CONAN_COLOR_DARK": "1"})
+    cp.removed_environment.append("MY_REMOVED_ENVVAR")
+    cp.cwd = tmp_path
+    cp.arguments.append("")  # intentionally empty
+    cp.add_option("*", "shared", "True")
+    expr = cp.bash_expression.getvalue()
+    assert "# BuildFeatureConstants.CMAKEFINDDEBUGMODE=ON" in expr
+    assert "MY_ENVVAR=ENVVAR_VALUE " in expr
+    assert "# CONAN_COLOR_DARK=1" in expr
+    assert f"cd {tmp_path} &&" in expr
+    assert "MY_REMOVED_ENVVAR= " in expr
+    assert '""' in expr
+    if cruizlib.globals.CONAN_MAJOR_VERSION == 1:
+        assert '-o "*:shared=True"' in expr
+    else:
+        assert '-o "*/*:shared=True"' in expr
+
+
+def test_cmdparams_zsh_expression(tmp_path: pathlib.Path) -> None:
+    """Expressions available in zsh evaluation."""
+    cp = CommandParameters(MOCKED_VERB, _mocked_worker)
+    cp.set_build_feature(BuildFeatureConstants.CMAKEFINDDEBUGMODE, "ON")
+    cp.added_environment.update({"MY_ENVVAR": "ENVVAR_VALUE", "CONAN_COLOR_DARK": "1"})
+    cp.removed_environment.append("MY_REMOVED_ENVVAR")
+    cp.cwd = tmp_path
+    cp.arguments.append("")  # intentionally empty
+    cp.add_option("*", "shared", "True")
+    expr = cp.zsh_expression.getvalue()
+    assert "# BuildFeatureConstants.CMAKEFINDDEBUGMODE=ON" in expr
+    assert "MY_ENVVAR=ENVVAR_VALUE " in expr
+    assert "# CONAN_COLOR_DARK=1" in expr
+    assert f"cd {tmp_path} &&" in expr
+    assert "MY_REMOVED_ENVVAR= " in expr
+    assert '""' in expr
+    if cruizlib.globals.CONAN_MAJOR_VERSION == 1:
+        assert '-o "*:shared=True"' in expr
+    else:
+        assert '-o "*/*:shared=True"' in expr
+    assert expr.startswith("setopt interactivecomments")
+
+
+def test_cmdparams_common_subdir(tmp_path: pathlib.Path) -> None:
+    """Set the Conan common subdirectory."""
+    cp = CommandParameters(MOCKED_VERB, _mocked_worker)
+    cp.common_subdir = tmp_path
+    assert cp.common_subdir == tmp_path
+
+
+def test_cmdparams_check_namedargs(tmp_path: pathlib.Path) -> None:
+    """Check passed named arguments."""
+    cp = CommandParameters(MOCKED_VERB, _mocked_worker)
+    cp.named_arguments["tmp_path"] = os.fspath(tmp_path)
+    assert "tmp_path" in cp.named_arguments
+    assert cp.named_arguments["tmp_path"] == os.fspath(tmp_path)
+
+
+def test_cmdparams_time_commands() -> None:
+    """Enable time commands."""
+    cp = CommandParameters(MOCKED_VERB, _mocked_worker)
+    cp.time_commands = True
+    assert cp.time_commands
+
+
+def test_cmdparams_v2_omit_test_folder() -> None:
+    """Conan2 omit test folder."""
+    cp = CommandParameters(MOCKED_VERB, _mocked_worker)
+    cp.v2_omit_test_folder = True
+    assert cp.v2_omit_test_folder
+    if cruizlib.globals.CONAN_MAJOR_VERSION == 1:
+        pass
+    else:
+        assert cp.to_args()[-1] == ""
+        assert cp.to_args()[-2] == "-tf"
+
+
+def test_cmdparams_v2_need_ref() -> None:
+    """Conan2 need reference."""
+    cp = CommandParameters(MOCKED_VERB, _mocked_worker)
+    cp.v2_need_reference = True
+    assert cp.v2_need_reference
+
+
+def test_cmdparams_extra_options() -> None:
+    """Adding extra options."""
+    cp = CommandParameters(MOCKED_VERB, _mocked_worker)
+    cp.extra_options = "extra_options"
+    assert cp.extra_options == "extra_options"

--- a/tests/interop/test_imports.py
+++ b/tests/interop/test_imports.py
@@ -6,6 +6,7 @@ import sys
 MODULES_TO_IMPORT = (
     "cruizlib.constants",
     "cruizlib.globals",
+    "cruizlib.interop.commandparameters",
     "cruizlib.interop.commonparameters",
     "cruizlib.interop.dependencygraph",
     "cruizlib.interop.message",


### PR DESCRIPTION
Added test.
To avoid longer tests, the internal implementation now uses the public properties rather than the internal attributes.