### PR TITLE
Refactor: pylint suppression for noisey warnings that do not offer be…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,7 +138,7 @@ commands = [
     ["mypy", "--warn-return-any", "src/cruizlib"],
     ["mypy", "tests"],
     ["pylint", "src/cruiz"],
-    ["pylint", "--enable=all", "src/cruizlib"],
+    ["pylint", "--enable=all", "--disable=locally-disabled,suppressed-message,fixme", "src/cruizlib"],
     ["pip", "install", "conan<2"],
     ["pylint", "--ignore-paths=^src/cruiz/pyside6/.*$,^src/cruiz/workers/api/v2/.*$", "src/cruiz"],  # assuming Conan1 APIs
 ]


### PR DESCRIPTION
…nefits

When you use #pylint: disable=... then when you've got all warnings enabled, you get both
- locally disabled
- suppressed message

from each instance. This is noise.

Any FIXME markup also warns. For now, just search for FIXME.