### PR TITLE
Tests: Re-add subprocess coverage, for things like meta commands

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -83,7 +83,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: pytest-coverage-${{ join(matrix.*, '-') }}-${{ github.event_name }}
-        path: .coverage
+        path: .coverage*
         if-no-files-found: error
         include-hidden-files: true
   report-coverage:
@@ -104,7 +104,7 @@ jobs:
         python -m pip install --upgrade pip wheel setuptools coverage
     - name: Combine Pytest coverage reports
       run: |
-        find . -name '.coverage' -maxdepth 2 -type f -exec python -m coverage combine --keep {} +
+        find . -name '.coverage*' -maxdepth 2 -type f -exec python -m coverage combine --keep {} +
         python -m coverage report --show-missing --skip-covered
         python -m coverage xml -o pytest-coverage.xml
     - name: Pytest coverage comment

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -171,6 +171,9 @@ testpaths = [
 [tool.pytest.ini_options]
 addopts = "--cache-clear --junitxml=pytest.xml --cov=cruizlib --cov-report=term-missing:skip-covered"
 
+[tool.coverage.run]
+patch = ["subprocess"]
+
 [tool.tox.env.test-latest1]
 description = "Run pytest targeting latest Conan 1"
 commands_pre = [["pip", "install", "-qe", ".[dev]"]]


### PR DESCRIPTION
There wasn't any coverage for modules run in subprocesses. This had been removed from a previous change, thinking it wasn't necessary, but it is. Modules like the meta worker needed it.